### PR TITLE
marc_tuefind.properties: use solrmarc index specification language in…

### DIFF
--- a/import/marc_tuefind.properties
+++ b/import/marc_tuefind.properties
@@ -20,9 +20,9 @@ publishDate = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getD
 publishDateSort = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getPublicationSortDate
 title = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getMainTitle
 title_auth = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getMainTitle
-title_short = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getTitleSubfield("a")
+title_short = 245a, clean
 title_sort = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getSortableTitleUnicode
-title_sub = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getTitleSubfield("b")
+title_sub = 245b, clean
 
 
 # additional common fields - All TueFind instances  (see schema_tufind_fields.xml)
@@ -39,7 +39,7 @@ mediatype = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getMed
 oldid = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getFirstSubfieldValueWithPrefix(035a,"(DE-576)")
 pages = {936h} ? (ind1 = 'u' && ind2 = 'w')
 record_selector = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getRecordSelectors
-rvk = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getRVKs
+rvk = 936a
 superior_ppn = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getSuperiorPPN
 urls_and_material_types = custom(de.unituebingen.ub.ubtools.solrmarcMixin.TuelibMixin), getUrlsAndMaterialTypes
 volume = {936d} ? (ind1 = 'u' && ind2 = 'w')


### PR DESCRIPTION
…stead of custom methods for rvk, title_short, title_sub