### PR TITLE
normalized PDA mechanics in RecordDataFormatter+RecordDriver

### DIFF
--- a/module/IxTheo/src/IxTheo/RecordDriver/SolrDefault.php
+++ b/module/IxTheo/src/IxTheo/RecordDriver/SolrDefault.php
@@ -338,4 +338,8 @@ class SolrDefault extends \TueFind\RecordDriver\SolrMarc
         }
         return $bible_references;
     }
+
+    public function isAvailableForPDA() {
+        return isset($this->fields['is_potentially_pda']) && $this->fields['is_potentially_pda'];
+    }
 }

--- a/module/KrimDok/src/KrimDok/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/KrimDok/src/KrimDok/View/Helper/Root/RecordDataFormatterFactory.php
@@ -33,7 +33,7 @@ class RecordDataFormatterFactory extends \TueFind\View\Helper\Root\RecordDataFor
         $this->addHBZ($spec);
         // PDA (KrimDok-specific)
         $spec->setTemplateLine(
-            'PDA', 'isAvailableForPDA', 'data-PDA.phtml'
+            'PDA', 'showPDA', 'data-PDA.phtml'
         );
         $this->addSubito($spec);
         $this->addVolumesAndArticles($spec);

--- a/module/TueFind/src/TueFind/RecordDriver/SolrDefault.php
+++ b/module/TueFind/src/TueFind/RecordDriver/SolrDefault.php
@@ -493,12 +493,15 @@ class SolrDefault extends \VuFind\RecordDriver\SolrMarc
             $this->fields['zdb_number'] : '';
     }
 
-    /** Check whether a record is potentially available for PDA
+    /**
+     * Check whether a record is available for PDA
+     * - Default false
+     * - implemented differently in IxTheo and KrimDok, so should be overridden there
      *
      * @return bool
      */
-    public function isPotentiallyPDA() {
-        return isset($this->fields['is_potentially_pda']) && $this->fields['is_potentially_pda'];
+    public function isAvailableForPDA() {
+        return false;
     }
 
     public function isSuperiorWork() {

--- a/module/TueFind/src/TueFind/RecordDriver/SolrMarc.php
+++ b/module/TueFind/src/TueFind/RecordDriver/SolrMarc.php
@@ -212,7 +212,7 @@ class SolrMarc extends SolrDefault
 
     public function showPDA() {
         $formats = $this->getFormats();
-        return (!empty($formats) && (in_array('Book', $formats)) && $this->isPotentiallyPDA());
+        return (!empty($formats) && (in_array('Book', $formats)) && $this->isAvailableForPDA());
     }
 
     public function showSubito() {


### PR DESCRIPTION
- isPotentiallyPDA (IxTheo) + isAvailableForPDA (KrimDok) have been normalized, there is an abstract isAvailableForPDA in TueFind return false that needs to be overridden (so IxTheo's function has been renamed + moved to IxTheo RecordDriver)
- RecordDataFormatterFactory: KrimDok now uses "showPDA", just like IxTheo, which then calls "isAvailableForPDA" for both systems