### PR TITLE
tuefind/overrides.less

### DIFF
--- a/themes/tuefind/less/overrides.less
+++ b/themes/tuefind/less/overrides.less
@@ -1,3 +1,7 @@
+a {
+  text-decoration: initial;
+}
+
 .active-filters {
   justify-content: flex-end;
 


### PR DESCRIPTION
Override VuFind 6.1 default setting for hyperlink text decoration (accessibility change), see #1375 