### PR TITLE
Search2: Avoid TueFind inheriting from IxTheo (use trait instead)

### DIFF
--- a/module/IxTheo/src/IxTheo/Search/Options/PluginManager.php
+++ b/module/IxTheo/src/IxTheo/Search/Options/PluginManager.php
@@ -8,11 +8,13 @@ class PluginManager extends \TueFind\Search\Options\PluginManager {
     public function __construct($configOrContainerInstance = null,
         array $v3config = []
     ) {
+        $this->aliases['search2'] = \IxTheo\Search\Search2\Options::class;
         $this->aliases['solr'] = \IxTheo\Search\Solr\Options::class;
         $this->aliases['keywordchainsearch'] = \IxTheo\Search\KeywordChainSearch\Options::class;
         $this->aliases['Subscriptions'] = \IxTheo\Search\Subscriptions\Options::class;
         $this->aliases['pdasubscriptions'] = \IxTheo\Search\PDASubscriptions\Options::class;
 
+        $this->factories[\IxTheo\Search\Search2\Options::class] = OptionsFactory::class;
         $this->factories[\IxTheo\Search\Solr\Options::class] = OptionsFactory::class;
         $this->factories[\IxTheo\Search\KeywordChainSearch\Options::class] = OptionsFactory::class;
         $this->factories[\IxTheo\Search\Subscriptions\Options::class] = OptionsFactory::class;

--- a/module/IxTheo/src/IxTheo/Search/Results/PluginManager.php
+++ b/module/IxTheo/src/IxTheo/Search/Results/PluginManager.php
@@ -5,11 +5,13 @@ namespace IxTheo\Search\Results;
 class PluginManager extends \TueFind\Search\Results\PluginManager {
     protected function _addAliasesAndFactories() {
         parent::_addAliasesAndFactories();
+        $this->aliases['search2'] = \IxTheo\Search\Search2\Results::class;
         $this->aliases['solr'] = \IxTheo\Search\Solr\Results::class;
         $this->aliases['keywordchainsearch'] = \IxTheo\Search\KeywordChainSearch\Results::class;
         $this->aliases['Subscriptions'] = \IxTheo\Search\Subscriptions\Results::class;
         $this->aliases['pdasubscriptions'] = \IxTheo\Search\PDASubscriptions\Results::class;
 
+        $this->factories[\IxTheo\Search\Search2\Results::class] = \VuFind\Search\Search2\ResultsFactory::class;
         $this->factories[\IxTheo\Search\Solr\Results::class] = \VuFind\Search\Solr\ResultsFactory::class;
         $this->factories[\IxTheo\Search\KeywordChainSearch\Results::class] = \VuFind\Search\Solr\ResultsFactory::class;
         $this->factories[\IxTheo\Search\Subscriptions\Results::class] = \IxTheo\Search\Subscriptions\ResultsFactory::class;

--- a/module/IxTheo/src/IxTheo/Search/Search2/Options.php
+++ b/module/IxTheo/src/IxTheo/Search/Search2/Options.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace IxTheo\Search\Search2;
+
+class Options extends \TueFind\Search\Search2\Options
+{
+
+}

--- a/module/IxTheo/src/IxTheo/Search/Search2/Params.php
+++ b/module/IxTheo/src/IxTheo/Search/Search2/Params.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace IxTheo\Search\Search2;
+
+class Params extends \TueFind\Search\Search2\Params
+{
+}

--- a/module/IxTheo/src/IxTheo/Search/Search2/Results.php
+++ b/module/IxTheo/src/IxTheo/Search/Search2/Results.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace IxTheo\Search\Search2;
+
+class Results extends \TueFind\Search\Search2\Results
+{
+    use \IxTheo\Search\Solr\ResultsTrait;
+}

--- a/module/IxTheo/src/IxTheo/Search/Solr/Results.php
+++ b/module/IxTheo/src/IxTheo/Search/Solr/Results.php
@@ -4,27 +4,5 @@ namespace IxTheo\Search\Solr;
 
 class Results extends \TueFind\Search\Solr\Results
 {
-    /**
-     * Returns the stored list of facets for the last search
-     *
-     * Contains special translation logic for ixtheo/relbib notation facets
-     *
-     * @param array $filter Array of field => on-screen description listing
-     * all of the desired facet fields; set to null to get all configured values.
-     *
-     * @return array        Facets data arrays
-     */
-    public function getFacetList($filter = null)
-    {
-        $list = parent::getFacetList($filter);
-        foreach ($list as $facetKey => $facet) {
-            if (in_array($facetKey, ['ixtheo_notation_facet', 'relbib_notation_facet'])) {
-                $prefix = 'ixtheo-';
-                foreach ($facet['list'] as $listKey => $listItem) {
-                    $list[$facetKey]['list'][$listKey]['displayText'] = $this->translate($prefix . $listItem['displayText']);
-                }
-            }
-        }
-        return $list;
-    }
+    use ResultsTrait;
 }

--- a/module/IxTheo/src/IxTheo/Search/Solr/ResultsTrait.php
+++ b/module/IxTheo/src/IxTheo/Search/Solr/ResultsTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace IxTheo\Search\Solr;
+
+/**
+ * This trait will be re-used in
+ * - Solr\Results
+ * - Search2\Results
+ */
+
+trait ResultsTrait {
+    /**
+     * Returns the stored list of facets for the last search
+     *
+     * Contains special translation logic for ixtheo/relbib notation facets
+     *
+     * @param array $filter Array of field => on-screen description listing
+     * all of the desired facet fields; set to null to get all configured values.
+     *
+     * @return array        Facets data arrays
+     */
+    public function getFacetList($filter = null)
+    {
+        $list = parent::getFacetList($filter);
+        foreach ($list as $facetKey => $facet) {
+            if (in_array($facetKey, ['ixtheo_notation_facet', 'relbib_notation_facet'])) {
+                $prefix = 'ixtheo-';
+                foreach ($facet['list'] as $listKey => $listItem) {
+                    $list[$facetKey]['list'][$listKey]['displayText'] = $this->translate($prefix . $listItem['displayText']);
+                }
+            }
+        }
+        return $list;
+    }
+}

--- a/module/TueFind/src/TueFind/Search/Search2/Results.php
+++ b/module/TueFind/src/TueFind/Search/Search2/Results.php
@@ -1,7 +1,7 @@
 <?php
 namespace TueFind\Search\Search2;
 
-class Results extends \IxTheo\Search\Solr\Results
+class Results extends \VuFind\Search\Search2\Results
 {
-    protected $backendId = 'Search2';
+
 }


### PR DESCRIPTION
(TueFind/Search/Search2/Results.php was inheriting from \IxTheo\Search\Solr\Results)