### PR TITLE
KfL: Support external session timeout mechanism

### DIFF
--- a/module/TueFind/config/module.config.php
+++ b/module/TueFind/config/module.config.php
@@ -102,14 +102,22 @@ $config = [
             'redirect-license' => [
                 'type'    => 'Laminas\Router\Http\Segment',
                 'options' => [
-                    'route'    => '/redirect-license/:id',
+                    'route'    => '/redirect-license/:id[/:proxy-url]',
                     'constraints' => [
-                        'id'   => '[^/]+',
+                        // The ID can either be a regular PPN, or a HAN-ID.
+                        'id'        => '[^/]+',
+                        // The Proxy-URL is sent by the HAN Server
+                        // if there was a timeout on an existing session
+                        // and a user needs to re-authenticate before
+                        // being able to use the resource again.
+                        // The URL will contain detailed information about
+                        // e.g. the last viewed page in the document.
+                        'proxy-url' => '.+',
                     ],
                     'defaults' => [
                         'controller' => 'Redirect',
                         'action'     => 'license',
-                    ]
+                    ],
                 ],
             ],
             'myresearch-publish' => [

--- a/module/TueFind/src/TueFind/Crypt/Base64Url.php
+++ b/module/TueFind/src/TueFind/Crypt/Base64Url.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TueFind\Crypt;
+
+/** 
+ * Described as "base64url" in the original Base64 RFC:
+ * https://www.rfc-editor.org/rfc/rfc4648.txt
+ *
+ * Basically use base64, but instead of / and + we use - and _.
+ * These characters can cause problems, especially /, even if URL encoded.
+ * 
+ * To allow /, it would be necessary to change apache config
+ * which we do not want to do for security reasons:
+ * https://httpd.apache.org/docs/2.4/mod/core.html#allowencodedslashes
+ */
+class Base64Url
+{
+    // The size of these arrays must be the same,
+    // will be used for search / replace.
+    const BASE64_SPECIFIC_CHARACTERS = ['/', '+'];
+    const BASE64_URL_SPECIFIC_CHARACTERS = ['-', '_'];
+    
+    public function encodeString(string $inputString): string
+    {
+        $base64 = base64_encode($inputString);
+        $base64Url = str_replace(['/', '+'], ['-', '_'], $base64);
+        return $base64Url;
+    } 
+    
+    public function decodeString(string $inputString): string
+    {
+        $base64 = str_replace(['-', '_'], ['/', '+'], $inputString);
+        $outputString = base64_decode($base64);
+        return $outputString;
+    }
+}

--- a/module/TueFind/src/TueFind/Crypt/Base64Url.php
+++ b/module/TueFind/src/TueFind/Crypt/Base64Url.php
@@ -23,13 +23,13 @@ class Base64Url
     public function encodeString(string $inputString): string
     {
         $base64 = base64_encode($inputString);
-        $base64Url = str_replace(['/', '+'], ['-', '_'], $base64);
+        $base64Url = str_replace(static::BASE64_SPECIFIC_CHARACTERS, static::BASE64_URL_SPECIFIC_CHARACTERS, $base64);
         return $base64Url;
     } 
     
     public function decodeString(string $inputString): string
     {
-        $base64 = str_replace(['-', '_'], ['/', '+'], $inputString);
+        $base64 = str_replace(static::BASE64_URL_SPECIFIC_CHARACTERS, static::BASE64_SPECIFIC_CHARACTERS, $inputString);
         $outputString = base64_decode($base64);
         return $outputString;
     }

--- a/module/TueFind/src/TueFind/Crypt/Base64Url.php
+++ b/module/TueFind/src/TueFind/Crypt/Base64Url.php
@@ -17,7 +17,7 @@ class Base64Url
 {
     // The size of these arrays must be the same,
     // will be used for search / replace.
-    const BASE64_SPECIFIC_CHARACTERS = ['/', '+'];
+    const BASE64_SPECIFIC_CHARACTERS = ['+', '/'];
     const BASE64_URL_SPECIFIC_CHARACTERS = ['-', '_'];
     
     public function encodeString(string $inputString): string

--- a/module/TueFind/src/TueFind/Service/KfL.php
+++ b/module/TueFind/src/TueFind/Service/KfL.php
@@ -217,7 +217,7 @@ class KfL
      *
      * @return string
      */
-    public function getUrlByHanID($hanId, ?string $url=null)
+    public function getUrlByHanID(string $hanId, ?string $url=null)
     {
         return $this->getUrl($this->getTitleInfoByHanID($hanId), $url);
     }

--- a/module/TueFind/src/TueFind/Service/KfL.php
+++ b/module/TueFind/src/TueFind/Service/KfL.php
@@ -43,7 +43,7 @@ class KfL
         foreach ($titles as $title) {
             $titleDetails = explode(';', $title);
             $parsedTitles[] = ['ppn' => $titleDetails[0],
-                               'kflId' => $titleDetails[1],
+                               'hanId' => $titleDetails[1],
                                'entitlement' => $titleDetails[2]];
         }
         $this->titles = $parsedTitles;
@@ -179,30 +179,57 @@ class KfL
     /**
      * Get the URL to access the given record via the KfL proxy.
      *
-     * @param \TueFind\RecordDriver\SolrMarc $record
+     * @param array $titleInfo
+     * @param string $url
+     *
+     * @return string
      */
-    public function getUrl(\TueFind\RecordDriver\SolrMarc $record): string
+    protected function getUrl(array $titleInfo, ?string $url=null): string
     {
-        $titleInfo = $this->getTitleInfo($record->getUniqueId());
         $requestData = $this->getRequestTemplate($titleInfo['entitlement']);
         $requestData['method'] = 'getHANID';
         $requestData['return'] = self::RETURN_REDIRECT;
-        $requestData['hanid'] = $titleInfo['kflId'];
-
-        if ($requestData['hanid'] == null)
-            throw new \Exception('Han-ID missing for title: ' . $record->getUniqueID());
+        $requestData['hanid'] = $titleInfo['hanId'];
+        if (!empty($url))
+            $requestData['url'] = $url;
 
         return $this->generateUrl($requestData);
     }
 
     /**
-     * Get information about a title, especially Kfl-ID and entitlement.
+     * Get the URL to access the given record via the KfL proxy.
+     *
+     * @param string $ppn
+     * @param string $url
+     *
+     * @return string
+     */
+    public function getUrlByPPN(string $ppn, ?string $url=null)
+    {
+        return $this->getUrl($this->getTitleInfoByPPN($ppn), $url);
+    }
+
+    /**
+     * Get the URL to access the given record via the KfL proxy.
+     *
+     * @param string $hanId
+     * @param string $url
+     *
+     * @return string
+     */
+    public function getUrlByHanID($hanId, ?string $url=null)
+    {
+        return $this->getUrl($this->getTitleInfoByHanID($hanId), $url);
+    }
+
+    /**
+     * Get information about a title, especially HAN-ID and entitlement.
      *
      * @param string $ppn
      *
      * @return array
      */
-    protected function getTitleInfo(string $ppn): array
+    protected function getTitleInfoByPPN(string $ppn): array
     {
         foreach ($this->titles as $title) {
             if ($title['ppn'] == $ppn)
@@ -210,6 +237,23 @@ class KfL
         }
 
         throw new \Exception('KfL title information missing for ppn: ' . $ppn);
+    }
+
+    /**
+     * Get information about a title
+     *
+     * @param string $hanId
+     *
+     * @return array
+     */
+    protected function getTitleInfoByHanID(string $hanId): array
+    {
+        foreach ($this->titles as $title) {
+            if ($title['hanId'] == $hanId)
+                return $title;
+        }
+
+        throw new \Exception('KfL title information missing for HAN ID: ' . $hanId);
     }
 
     /**


### PR DESCRIPTION
Base62 seems to be used primarily for numbers. For text encoding, there seem to be different non standardized approaches. That's why i switched to base64url instead, which is described by RFC4648 and easy to implement.