### PR TITLE
robots.txt: Explicitly allow /Authority (and /Record) to avoid conflicts with the disallow /Author rule

### DIFF
--- a/public/robots/ixtheo.txt
+++ b/public/robots/ixtheo.txt
@@ -12,6 +12,8 @@ User-agent: SEOkicks-Robot
 Disallow: /
 
 User-agent: *
+Allow: /Authority/
+Allow: /Record/
 Disallow: /AJAX
 Disallow: /Alphabrowse
 Disallow: /Author

--- a/public/robots/krimdok.txt
+++ b/public/robots/krimdok.txt
@@ -12,6 +12,8 @@ User-agent: SEOkicks-Robot
 Disallow: /
 
 User-agent: *
+Allow: /Authority/
+Allow: /Record/
 Disallow: /AJAX
 Disallow: /Alphabrowse
 Disallow: /Author

--- a/public/robots/relbib.txt
+++ b/public/robots/relbib.txt
@@ -12,6 +12,8 @@ User-agent: SEOkicks-Robot
 Disallow: /
 
 User-agent: *
+Allow: /Authority/
+Allow: /Record/
 Disallow: /AJAX
 Disallow: /Alphabrowse
 Disallow: /Author


### PR DESCRIPTION
See also: #1609