### PR TITLE
Hierarchical Facet for Collections

### DIFF
--- a/import/index_java/src/org/tuefind/index/IxTheoBiblio.java
+++ b/import/index_java/src/org/tuefind/index/IxTheoBiblio.java
@@ -204,4 +204,20 @@ public class IxTheoBiblio extends TueFindBiblio {
             return translateTopic(values.iterator().next(), langShortcut);
         return "";
     }
+
+    public Set<String> getCollectionsHierarchy(final Record record) {
+        final Set<String> collections = new HashSet<>();
+
+        // This is just a first proof-of-concept so we generate this based on the record selector.
+        // Later on we should get the information from LOK 866, which is not yet present in the data.
+        // Example: SPQUE#Universitätsbibliothek Marburg#SPSAM#Archiv des Religionswissenschaftlichen Medien- und Informationsdienstes e. V. (REMID)
+        Set<String> recordSelectors = getRecordSelectors(record);
+        if (recordSelectors.contains("remi")) {
+            // Example values for hierarchical facets, see: https://vufind.org/wiki/configuration:facets
+            collections.add("0/Universitätsbibliothek Marburg/");
+            collections.add("1/Universitätsbibliothek Marburg/Archiv des Religionswissenschaftlichen Medien- und Informationsdienstes e. V. (REMID)/");
+        }
+
+        return collections;
+    }
 }

--- a/import/marc_ixtheo.properties
+++ b/import/marc_ixtheo.properties
@@ -19,6 +19,7 @@ author_synonyms = 109a
 bible_ranges = BIRa
 bundle_id = BSPa
 canon_law_ranges = CALa
+collections_hierarchy = custom(org.tuefind.index.IxTheoBiblio), getCollectionsHierarchy
 container_issue = 936f
 corporation = custom(org.tuefind.index.CreatorTools), getAuthorsFilteredByRelator(110abg:111abcdegn:710abg:711abcdegn,110:111:710:711,firstAuthorRoles|secondAuthorRoles|nonCreativeRoles)
 era_facet_de = custom(org.tuefind.index.TueFindBiblio), getTimeTranslated(610y:611y:630y:648a:648y:650y:651y:655y:689abctnpzl9g, "$p. :$n :$x|:$z[()]:$9g[()]: ", "de")

--- a/solr/vufind/biblio/conf/schema_ixtheo_fields.xml
+++ b/solr/vufind/biblio/conf/schema_ixtheo_fields.xml
@@ -7,6 +7,7 @@
     <field name="author_synonyms" type="text" indexed="true" stored="true" termVectors="true" multiValued="true" storeOffsetsWithPositions="true"/>
     <field name="bible_ranges" type="string" indexed="true" stored="true" />
     <field name="canon_law_ranges" type="string" indexed="true" stored="true" />
+    <field name="collections_hierarchy" type="textFacet" indexed="true" stored="true" multiValued="true" />
     <field name="corporation" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="era_facet_de" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="era_facet_el" type="textFacet" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
This change will add a sample Solr field that can be used as base for a hierarchical facet.
It can be enabled in the `facets.ini` locally on ptah for first testing/demo purposes:
```
[Results]
collections_hierarchy = "Collections (Hierarchy)"

[SpecialFacets]
hierarchical[] = collections_hierarchy
```

Since the data is not yet present in LOK 866, the record selector for REMID  is used for a simple example instead.
Sample screenshot:

![grafik](https://github.com/ubtue/tuefind/assets/26873381/48c8c382-b199-4663-90dc-8f6deda03cba)
