### PR TITLE
robots.txt: Also block lowercase search routes for RelBib

### DIFF
--- a/public/robots/relbib.txt
+++ b/public/robots/relbib.txt
@@ -30,8 +30,11 @@ Disallow: /pdaproxy
 Disallow: /proxy
 Disallow: /RssFeed
 Disallow: /Search/Advanced
+Disallow: /search/advanced
 Disallow: /Search/Results
+Disallow: /search/results
 Disallow: /Search2
+Disallow: /search2
 Disallow: /Summon
 Disallow: /SummonRecord
 Disallow: /WikidataProxy


### PR DESCRIPTION
We already blocked this for all other systems, but not for RelBib yet