### PR TITLE
Remove deprecated config from solrconfig

### DIFF
--- a/solr/vufind/authority/conf/solrconfig.xml
+++ b/solr/vufind/authority/conf/solrconfig.xml
@@ -273,12 +273,6 @@
     handleSelect=false will use solr1.1 style error formatting
     -->
   <requestDispatcher handleSelect="true" >
-    <!--Make sure your system has some authentication before enabling remote streaming!  -->
-    <requestParsers enableRemoteStreaming="false"
-                    enableStreamBody="true"
-                    multipartUploadLimitInKB="2048"
-                    formdataUploadLimitInKB="2048"/>
-
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)

--- a/solr/vufind/biblio/conf/solrconfig_ixtheo.xml
+++ b/solr/vufind/biblio/conf/solrconfig_ixtheo.xml
@@ -284,10 +284,6 @@
     handleSelect=false will use solr1.1 style error formatting
     -->
   <requestDispatcher handleSelect="true" >
-    <!--Make sure your system has some authentication before enabling remote streaming!  -->
-    <requestParsers multipartUploadLimitInKB="2048000"
-                    formdataUploadLimitInKB="2048"/>
-
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)

--- a/solr/vufind/biblio/conf/solrconfig_ixtheo.xml
+++ b/solr/vufind/biblio/conf/solrconfig_ixtheo.xml
@@ -238,12 +238,6 @@
          queryResultCache. -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-    <!-- This entry enables an int hash representation for filters (DocSets)
-         when the number of items in the set is less than maxSize.  For smaller
-         sets, this representation is more memory efficient, more efficient to
-         iterate over, and faster to take intersections.  -->
-    <HashDocSet maxSize="3000" loadFactor="0.75"/>
-
     <!-- a newSearcher event is fired whenever a new searcher is being prepared
          and there is a current searcher handling requests (aka registered). -->
     <!-- QuerySenderListener takes an array of NamedList and executes a
@@ -291,9 +285,7 @@
     -->
   <requestDispatcher handleSelect="true" >
     <!--Make sure your system has some authentication before enabling remote streaming!  -->
-    <requestParsers enableRemoteStreaming="true"
-                    enableStreamBody="true"
-                    multipartUploadLimitInKB="2048000"
+    <requestParsers multipartUploadLimitInKB="2048000"
                     formdataUploadLimitInKB="2048"/>
 
     <!-- Set HTTP caching related parameters (for proxy caches and clients).

--- a/solr/vufind/biblio/conf/solrconfig_krimdok.xml
+++ b/solr/vufind/biblio/conf/solrconfig_krimdok.xml
@@ -284,10 +284,6 @@
     handleSelect=false will use solr1.1 style error formatting
     -->
   <requestDispatcher handleSelect="true" >
-    <!--Make sure your system has some authentication before enabling remote streaming!  -->
-    <requestParsers multipartUploadLimitInKB="2048000"
-                    formdataUploadLimitInKB="2048"/>
-
     <!-- Set HTTP caching related parameters (for proxy caches and clients).
 
          To get the behaviour of Solr 1.2 (ie: no caching related headers)

--- a/solr/vufind/biblio/conf/solrconfig_krimdok.xml
+++ b/solr/vufind/biblio/conf/solrconfig_krimdok.xml
@@ -285,9 +285,7 @@
     -->
   <requestDispatcher handleSelect="true" >
     <!--Make sure your system has some authentication before enabling remote streaming!  -->
-    <requestParsers enableRemoteStreaming="true"
-                    enableStreamBody="true"
-                    multipartUploadLimitInKB="2048000"
+    <requestParsers multipartUploadLimitInKB="2048000"
                     formdataUploadLimitInKB="2048"/>
 
     <!-- Set HTTP caching related parameters (for proxy caches and clients).


### PR DESCRIPTION
Starting on Solr 9.3, these configs were deprecated:
<requestParsers 
     enableRemoteStreaming="true"
     enableStreamBody="true" />

<HashDocSet maxSize="3000" loadFactor="0.75"/>