### PR TITLE
Optimize translation of [Unassigned] to allow facet filter

### DIFF
--- a/local/tuefind/instances/bibstudies/config/vufind/facets.ini
+++ b/local/tuefind/instances/bibstudies/config/vufind/facets.ini
@@ -265,16 +265,29 @@ special_facets   = "daterange"
 ; Please note that the "filter" textbox control in the expanded facet list
 ; will be disabled for translated facets due to technical limitations of its
 ; implementation. Filtering can only be applied to raw values in the index.
+;TueFind: if you only want to translate "[Unassigned]", please use the translated_facets_unassigned section instead!
 ;translated_facets[] = institution
 ;translated_facets[] = building
-;translated_facets[] = format
-;translated_facets[] = callnumber-first:CallNumberFirst
-; If you change the default Dewey indexing to omit translation mapping at index time,
-; you can uncomment the below configuration to take advantage of on-the-fly
-; translation into multiple languages.
-;translated_facets[] = dewey-ones:DDC23:%%raw%% - %%translated%%
-;translated_facets[] = dewey-tens:DDC23:%%raw%% - %%translated%%
-;translated_facets[] = dewey-hundreds:DDC23:%%raw%% - %%translated%%
+;translated_facets[]   = author_facet
+;translated_facets[]   = dewey-hundreds        ; disabled, because special translation logic is used, see IxTheo\Search\Solr\ResultsTrait
+;translated_facets[]   = era_facet
+translated_facets[]   = format
+;translated_facets[]   = genre_facet
+;translated_facets[]   = geographic_facet
+translated_facets[]   = is_open_access
+;translated_facets[]   = ixtheo_notation_facet ; disabled, because special translation logic is used, see IxTheo\Search\Solr\ResultsTrait
+translated_facets[]   = language
+translated_facets[]   = mediatype
+;translated_facets[]   = publisher_facet
+;translated_facets[]   = collections_hierarchy
+;translated_facets[]   = topic_facet
+
+; TueFind-specific
+; This is needed for facets where we only want to translate the "unassigned" entry.
+; We don't want this in the default translated_facets section, since this would also
+; lead to e.g. filtering mechanisms being disabled.
+translated_facets_unassigned[] = author_facet
+translated_facets_unassigned[] = publisher_facet
 
 ; Any facets named here will be treated as a delimited facet.
 ; Delimited facets can be used to display a text value for otherwise incomprehensible

--- a/local/tuefind/instances/ixtheo/config/vufind/facets.ini
+++ b/local/tuefind/instances/ixtheo/config/vufind/facets.ini
@@ -265,10 +265,10 @@ special_facets   = "daterange"
 ; Please note that the "filter" textbox control in the expanded facet list
 ; will be disabled for translated facets due to technical limitations of its
 ; implementation. Filtering can only be applied to raw values in the index.
+;TueFind: if you only want to translate "[Unassigned]", please use the translated_facets_unassigned section instead!
 ;translated_facets[] = institution
 ;translated_facets[] = building
-; remember => if you comment this, "[Unassigned]" will also NOT be translated anymore!
-translated_facets[]   = author_facet
+;translated_facets[]   = author_facet
 ;translated_facets[]   = dewey-hundreds        ; disabled, because special translation logic is used, see IxTheo\Search\Solr\ResultsTrait
 ;translated_facets[]   = era_facet
 translated_facets[]   = format
@@ -278,7 +278,7 @@ translated_facets[]   = is_open_access
 ;translated_facets[]   = ixtheo_notation_facet ; disabled, because special translation logic is used, see IxTheo\Search\Solr\ResultsTrait
 translated_facets[]   = language
 translated_facets[]   = mediatype
-translated_facets[]   = publisher_facet
+;translated_facets[]   = publisher_facet
 translated_facets[]   = collections_hierarchy
 ;translated_facets[]   = topic_facet
 
@@ -288,6 +288,13 @@ translated_facets[]   = collections_hierarchy
 ;translated_facets[] = dewey-ones:DDC23:%%raw%% - %%translated%%
 ;translated_facets[] = dewey-tens:DDC23:%%raw%% - %%translated%%
 ;translated_facets[] = dewey-hundreds:DDC23:%%raw%% - %%translated%%
+
+; TueFind-specific
+; This is needed for facets where we only want to translate the "unassigned" entry.
+; We don't want this in the default translated_facets section, since this would also
+; lead to e.g. filtering mechanisms being disabled.
+translated_facets_unassigned[] = author_facet
+translated_facets_unassigned[] = publisher_facet
 
 ; Any facets named here will be treated as a delimited facet.
 ; Delimited facets can be used to display a text value for otherwise incomprehensible

--- a/local/tuefind/instances/relbib/config/vufind/facets.ini
+++ b/local/tuefind/instances/relbib/config/vufind/facets.ini
@@ -263,7 +263,8 @@ special_facets   = "daterange"
 ; Please note that the "filter" textbox control in the expanded facet list
 ; will be disabled for translated facets due to technical limitations of its
 ; implementation. Filtering can only be applied to raw values in the index.
-translated_facets[]   = author_facet
+;TueFind: if you only want to translate "[Unassigned]", please use the translated_facets_unassigned section instead!
+;translated_facets[]   = author_facet
 ;translated_facets[]   = dewey-hundreds        ; disabled, because special translation logic is used, see IxTheo\Search\Solr\ResultsTrait
 ;translated_facets[]   = era_facet
 translated_facets[]   = format
@@ -275,6 +276,13 @@ translated_facets[]   = language
 translated_facets[]   = mediatype
 translated_facets[]   = publisher_facet
 ;translated_facets[]   = topic_facet
+
+; TueFind-specific
+; This is needed for facets where we only want to translate the "unassigned" entry.
+; We don't want this in the default translated_facets section, since this would also
+; lead to e.g. filtering mechanisms being disabled.
+translated_facets_unassigned[] = author_facet
+translated_facets_unassigned[] = publisher_facet
 
 ; Any facets named here will be treated as a delimited facet.
 ; Delimited facets can be used to display a text value for otherwise incomprehensible

--- a/module/TueFind/src/TueFind/Search/Solr/Options.php
+++ b/module/TueFind/src/TueFind/Search/Solr/Options.php
@@ -2,4 +2,24 @@
 
 namespace TueFind\Search\Solr;
 
-class Options extends \VuFind\Search\Solr\Options {}
+class Options extends \VuFind\Search\Solr\Options {
+    // TueFind-specific: see facets.ini for more detailed description
+    protected $translatedFacetsUnassigned = [];
+
+    public function __construct(\VuFind\Config\PluginManager $configLoader) {
+        parent::__construct($configLoader);
+
+        $facetSettings = $configLoader->get($this->facetsIni);
+
+        if (
+            isset($facetSettings->Advanced_Settings->translated_facets_unassigned)
+            && count($facetSettings->Advanced_Settings->translated_facets_unassigned) > 0
+        ) {
+            $this->translatedFacetsUnassigned = $facetSettings->Advanced_Settings->translated_facets_unassigned->toArray();
+        }
+    }
+
+    public function getTranslatedFacetsUnassigned(): array {
+        return $this->translatedFacetsUnassigned;
+    }
+}


### PR DESCRIPTION
Notes:
- Bibstudies didn't have facet translations enabled yet at all, so i added that.
- Churchlaw seems to directly use the settings from ixtheo via symlink, so no changes necessary there
- KrimDok uses facet translations, but you can't obviously see [Unassigned] values in the frontend, so i didn't add unassigned translation for the specific fields