### PR TITLE
Enabling vufinds SDI for E-Mail Alerts

### DIFF
--- a/local/tuefind/instances/krimdok/config/vufind/config.ini
+++ b/local/tuefind/instances/krimdok/config/vufind/config.ini
@@ -446,7 +446,7 @@ schedule_searches = true
 ; Should we always send a scheduled search email the first time we run notices
 ; after a user has subscribed (true), or should we only send an email when there
 ; is actually something new (false, default)
-force_first_scheduled_email = true
+force_first_scheduled_email = false
 
 ; When schedule_searches is set to true, you can customize the schedule frequencies
 ; here -- just use the number of days between notifications in the brackets. Labels


### PR DESCRIPTION
Tested locally on an IxTheo instance. For Testing the force_first_scheduled_email is set to true, this should be set to false should this change ever go live.