### PR TITLE
Change logic for shown ISBNs

### DIFF
--- a/module/IxTheo/src/IxTheo/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/IxTheo/src/IxTheo/View/Helper/Root/RecordDataFormatterFactory.php
@@ -144,7 +144,7 @@ class RecordDataFormatterFactory extends \TueFind\View\Helper\Root\RecordDataFor
         $spec->setLine('Bibliography', 'getBibliographyNotes');
         // Clean ISBN with schema.org-property (IxTheo-specific)
         $spec->setLine(
-            'ISBN', 'getCleanISBN', null,
+            'ISBN', 'getISBNs', null,
             ['prefix' => '<span property="isbn">', 'suffix' => '</span>']
         );
         // ISSN with schema.org-property (IxTheo-specific)

--- a/module/TueFind/src/TueFind/Marc/MarcReader.php
+++ b/module/TueFind/src/TueFind/Marc/MarcReader.php
@@ -24,7 +24,18 @@ class MarcReader extends \VuFind\Marc\MarcReader
 
     public function getMarcRecord() {
         return $this->getMarcReader()->getRawMarcRecords();
+    }
 
+    /**
+     * Get subfields as assoc array for a given field array.
+     * Repeatable subfields are not supported!
+     */
+    public function getSubfieldsAssoc(array $field): array {
+        $result = [];
+        foreach ($field['subfields'] as $subfield) {
+            $result[$subfield['code']] = $subfield['data'];
+        }
+        return $result;
     }
 
 }

--- a/module/TueFind/src/TueFind/RecordDriver/Feature/MarcAdvancedTrait.php
+++ b/module/TueFind/src/TueFind/RecordDriver/Feature/MarcAdvancedTrait.php
@@ -177,10 +177,14 @@ trait MarcAdvancedTrait
         // Show 0209 in the exact way of writing, without normalization
 
         // We cannot just call getFieldArray once, because it will NOT keep the subfield order
-        $isbns = array_merge(
-            $this->getFieldArray('020', ['9'], false),
-            $this->getFieldArray('020', ['a'], false),
-        );
+        $isbns = [];
+        foreach ($this->getMarcReader()->getFields('020') as $field) {
+            $subfields = $this->getMarcReader()->getSubfieldsAssoc($field);
+            if (isset($subfields['9']))
+                $isbns[] = $subfields['9'];
+            elseif (isset($subfields['a']))
+                $isbns[] = $subfields['a'];
+        }
 
         return array_unique($isbns);
     }


### PR DESCRIPTION
Note: KrimDok already uses the VuFind default in the RecordDataFormatter, which is getISBNs (instead of getCleanISBN).