### PR TITLE
Add pre-commit hook for qa+formatting checks for PHP/PHTML

### DIFF
--- a/git-config/hooks/pre-commit
+++ b/git-config/hooks/pre-commit
@@ -2,6 +2,8 @@
 #
 # Git hook for e.g. executing code checks before commit
 #
+set -o errexit -o nounset
+
 readonly CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 readonly ADDED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 readonly MODIFIED_UNADDED_FILES=$(git ls-files --modified)

--- a/git-config/hooks/pre-commit
+++ b/git-config/hooks/pre-commit
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Git hook for e.g. executing code checks before commit
+#
+readonly CHANGED_FILES="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+readonly ADDED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+readonly MODIFIED_UNADDED_FILES=$(git ls-files --modified)
+readonly GIT_ROOT=$(git rev-parse --show-toplevel)
+readonly DIR="$(dirname $(readlink --canonicalize "$0"))"
+readonly DIR_VUFIND="$DIR/../../"
+
+# Execute a command once if a file of a certain pattern has changed
+# (e.g. update solr config & restart service if one of the config files changes)
+# $1 - command
+# $2 - grep pattern (extended regexp)
+# $3 - message
+run_if_file_changed() {
+    echo "$CHANGED_FILES" | grep --extended-regexp --quiet "$2" && echo "$3" && eval "$1"
+}
+
+echo "Executing code quality checks (git hook pre-commit)"
+
+# Java Import routines (not checked yet, code to be merged with section below)
+#run_if_file_changed "$DIR_VUFIND/import/tuefind_check_code.sh" "\.java" "JAVA files changed, checking code..."
+
+for ADDED_FILE in $ADDED_FILES; do
+
+    # sanity check: We only want to modify files within our custom modules/themes,
+    #               so we use a whitelist, else we might run into problems
+    #               e.g. when pulling from vufind-org upstream
+    #               and solving merge conflicts
+    if [[ $ADDED_FILE =~ (module/(TueFind|TueFindApi|TueFindSearch|IxTheo|KrimDok)/)|(themes/(tuefind|tuefind2|ixtheo|ixtheo2|relbib2|bibstudies|churchlaw|krimdok2)/) ]]; then
+
+        extension="${ADDED_FILE##*.}"
+        if [[ $extension == "php" || $extension == "phtml" ]]; then
+
+            # sanity check: If there have been unadded changes between add & commit,
+            # we skip the optimization so we dont add unwanted changes
+            if [[ "$MODIFIED_UNADDED_FILES" == *"$ADDED_FILE"* ]]; then
+                echo "pre-commit: Skipping code optimizations for $ADDED_FILE because we have unadded changes"
+            else
+                ADDED_FILE_PATH="$GIT_ROOT/$ADDED_FILE"
+                echo "pre-commit: Optimizing code style for $ADDED_FILE"
+
+                # Note: This example only uses php-cs-fixer, but the build.xml contains multiple tools like rector, phpstan, etc.
+
+                if [[ $extension == "php" ]]; then
+                    "$DIR_VUFIND/vendor/bin/phpstan" "--configuration=$DIR_VUFIND/tests/phpstan.neon" "--memory-limit=2G" "analyze" "--no-progress" "$ADDED_FILE_PATH"
+                    # phpcbf-related notes:
+                    # - will output unneccessary stuff even if in quiet mode (-q), so we pipe to /dev/null
+                    # - will auto fix errors, but in case there are non-fixable errors remaining (e.g. missing comments) it will exit with code 2, and we don't want to abort there
+                    "$DIR_VUFIND/vendor/bin/phpcbf" "--standard=$DIR_VUFIND/tests/phpcs.xml" "-q" "$ADDED_FILE_PATH" > /dev/null 2&>1 || test $? -eq 2
+                    "$DIR_VUFIND/vendor/bin/php-cs-fixer" fix "--config=$DIR_VUFIND/tests/vufind.php-cs-fixer.php" --quiet "$ADDED_FILE_PATH"
+                elif [[ $extension == "phtml" ]]; then
+                    "$DIR_VUFIND/vendor/bin/php-cs-fixer" fix "--config=$DIR_VUFIND/tests/vufind_templates.php-cs-fixer.php" --quiet "$ADDED_FILE_PATH"
+                fi
+
+                git add "$ADDED_FILE_PATH"
+            fi
+        fi
+    fi
+done


### PR DESCRIPTION
Note: This is inspired by another pre-commit hook which already exists within ub_tools.
See also: https://github.com/ubtue/ub_tools/blob/master/git-config/hooks/pre-commit

It re-uses checks for PHP/PHTML based on already existing vufind-org configurations.