### PR TITLE
First setup for "Index Augustinianus"

### DIFF
--- a/clean_vufind_cache.sh
+++ b/clean_vufind_cache.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 VUFIND_LOCAL_DIR="/usr/local/vufind/local/tuefind/instances"
 
-for i in "ixtheo" "relbib" "bibstudies" "krimdok" "churchlaw"
+for i in "ixtheo" "relbib" "bibstudies" "churchlaw" "augustine" "krimdok"
 do
     echo "Removing ${VUFIND_LOCAL_DIR}/${i}/cache/*"
     /bin/rm -rf ${VUFIND_LOCAL_DIR}/${i}/cache/*

--- a/import/index_java/src/org/tuefind/index/IxTheoBiblio.java
+++ b/import/index_java/src/org/tuefind/index/IxTheoBiblio.java
@@ -171,6 +171,10 @@ public class IxTheoBiblio extends TueFindBiblio {
         return translated_topics;
     }
 
+    public String getIsAugustine(final Record record) {
+        return record.getVariableFields("AUG").isEmpty() ? "false" : "true";
+    }
+
     public String getIsCanonLaw(final Record record) {
         return record.getVariableFields("CAN").isEmpty() ? "false" : "true";
     }

--- a/import/marc_ixtheo.properties
+++ b/import/marc_ixtheo.properties
@@ -54,6 +54,7 @@ geographic_facet_pt = custom(org.tuefind.index.TueFindBiblio), getRegionTranslat
 geographic_facet_ru = custom(org.tuefind.index.TueFindBiblio), getRegionTranslated(600z:610z:611z:630z:648z:650z:651az:655z:689abctnpzl9g, "$p. :$n :$x|:$z[()]:$9g[()]: ", "ru")
 geographic_facet_el = custom(org.tuefind.index.TueFindBiblio), getRegionTranslated(600z:610z:611z:630z:648z:650z:651az:655z:689abctnpzl9g, "$p. :$n :$x|:$z[()]:$9g[()]: ", "el")
 has_ita_t_subfield = custom(org.tuefind.index.IxTheoBiblio), hasITAtSubfield
+is_augustine = custom(org.tuefind.index.IxTheoBiblio), getIsAugustine
 is_biblical_studies = custom(org.tuefind.index.BiblicalStudiesBiblio), getIsBiblicalStudies
 is_canon_law = custom(org.tuefind.index.IxTheoBiblio), getIsCanonLaw
 is_hybrid = custom(org.tuefind.index.TueFindBiblio), isHybrid

--- a/index-alphabetic-browse_ixtheo.sh
+++ b/index-alphabetic-browse_ixtheo.sh
@@ -198,5 +198,7 @@ GenerateIndexForSystem &
 GenerateIndexForSystem "is_religious_studies" &
 GenerateIndexForSystem "is_biblical_studies" &
 GenerateIndexForSystem "is_canon_law" &
+# This will be inactive until Index Augustinianus goes live to avoid increasing pipeline runtimes on the live server:
+#GenerateIndexForSystem "is_augustine" &
 wait
 echo "Finished generating alphabrowse indices..."

--- a/local/tuefind/instances/augustine/cache/.gitignore
+++ b/local/tuefind/instances/augustine/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/local/tuefind/instances/augustine/config/vufind/AccountMenu.yaml
+++ b/local/tuefind/instances/augustine/config/vufind/AccountMenu.yaml
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/AccountMenu.yaml

--- a/local/tuefind/instances/augustine/config/vufind/FeedbackForms.yaml
+++ b/local/tuefind/instances/augustine/config/vufind/FeedbackForms.yaml
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/FeedbackForms.yaml

--- a/local/tuefind/instances/augustine/config/vufind/NoILS.ini
+++ b/local/tuefind/instances/augustine/config/vufind/NoILS.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/NoILS.ini

--- a/local/tuefind/instances/augustine/config/vufind/README.txt
+++ b/local/tuefind/instances/augustine/config/vufind/README.txt
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/README.txt

--- a/local/tuefind/instances/augustine/config/vufind/RecordTabs.ini
+++ b/local/tuefind/instances/augustine/config/vufind/RecordTabs.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/RecordTabs.ini

--- a/local/tuefind/instances/augustine/config/vufind/Search2.ini
+++ b/local/tuefind/instances/augustine/config/vufind/Search2.ini
@@ -1,0 +1,322 @@
+; This configuration file can be used to set up a secondary Solr index that behaves
+; similarly to VuFind's default search. This instance is accessible under /Search2
+; URLs within VuFind.
+;
+; This can be used in combination with Combined Search (see Combined.ini) to create
+; a tabbed interface searching multiple indexes. It can also be useful for pulling
+; in results from an external/third-party index.
+;
+; Most of the settings found in searches.ini and facets.ini can be dropped into
+; this file and will behave the same way. Some selected settings from config.ini
+; that apply only to the main Solr index are also overridden here. To ease
+; maintenance of documentation, comments from those files are not duplicated here.
+; See those files for more details of how all settings work. Look for section
+; marker comments within this file to see where groups of settings come from.
+
+; ---------- config.ini settings ----------
+
+[Index]
+url             = http://localhost:8983/solr
+default_core    = biblio
+maxBooleanClauses = 1024
+timeout = 30
+default_dismax_handler = edismax
+
+[Spelling]
+enabled = true
+limit   = 3
+phrase = false
+expand  = true
+simple = false
+skip_numeric = true
+
+[Record]
+next_prev_navigation = false
+related[] = Similar
+
+; ---------- searches.ini settings ----------
+
+[General]
+default_handler = FulltextOnly
+default_sort = relevance
+default_view = list
+default_limit = 20
+;limit_options        = 10,20,40,60,80,100
+case_sensitive_bools = true
+case_sensitive_ranges = true
+
+default_top_recommend[] = TopFacets:ResultsTop:Search2
+default_top_recommend[] = SpellingSuggestions
+default_top_recommend[] = VisualFacets:Visual_Settings
+default_side_recommend[] = SideFacets:Results:CheckboxFacets:Search2
+;default_noresults_recommend[] = SwitchTab
+;default_noresults_recommend[] = SwitchType
+;default_noresults_recommend[] = SwitchQuery:::fuzzy
+;default_noresults_recommend[] = SpellingSuggestions
+default_noresults_recommend[] = RemoveFilters
+
+highlighting = false
+;highlighting_fields = *
+snippets = false
+retain_filters_by_default = true
+always_display_reset_filters = false
+;default_filters[] = "format:Book"
+;default_filters[] = "institution:MyInstitution"
+;default_filters[] = "(format:Book AND institution:MyInstitution)"
+;default_record_fields = "*,score"
+;display_versions = true
+;load_results_with_js = true
+;top_paginator = simple
+
+[Cache]
+type = File
+
+[Basic_Searches]
+;AllFields           = "All Fields"
+;Title               = Title
+;JournalTitle        = "Journal Title"
+;Author              = Author
+;Subject             = Subject
+;CallNumber          = "Call Number"
+;ISN                 = "ISBN/ISSN"
+;Coordinate        = Coordinates
+;tag                 = Tag
+
+FulltextOnly        = "Fulltext Only"
+FulltextWithSynonyms= "Fulltext With Language Synonyms"
+FulltextAllSynonyms = "Fulltext With All Synonyms"
+[Advanced_Searches]
+AllFields           = adv_search_all
+Title               = adv_search_title
+;JournalTitle        = adv_search_journaltitle
+;Author              = adv_search_author
+Subject             = adv_search_subject
+CallNumber          = adv_search_callnumber
+ISN                 = adv_search_isn
+publisher           = adv_search_publisher
+Series              = adv_search_series
+year                = adv_search_year
+toc                 = adv_search_toc
+;Coordinate        = Coordinates
+
+[Sorting]
+relevance = sort_relevance
+year = sort_year
+year asc = sort_year_asc
+callnumber-sort = sort_callnumber
+;dewey-sort = sort_callnumber
+author = sort_author
+title = sort_title
+
+[HiddenSorting]
+;pattern[] = .*
+
+[DefaultSortingByType]
+CallNumber = callnumber-sort
+WorkKeys = year
+
+[SideRecommendations]
+;Subject[]          = SideFacets
+;Subject[]          = OpenLibrarySubjectsDeferred:lookfor:5:true:topic,place,person,time
+
+[TopRecommendations]
+Author[]            = AuthorFacets
+Author[]            = SpellingSuggestions
+;Author[]           = WorldCatIdentities
+CallNumber[]        = "TopFacets:ResultsTop"
+WorkKeys[]          = false
+
+[NoResultsRecommendations]
+CallNumber[] = SwitchQuery::wildcard:truncatechar
+CallNumber[] = RemoveFilters
+;CallNumber[] = AlphaBrowseLink:lcc
+
+[RSS]
+sort = "last_indexed desc"
+
+[Autocomplete]
+enabled = false
+default_handler = Search2
+formatting_rule[*] = "phrase"
+formatting_rule[tag] = "none"
+
+[Autocomplete_Types]
+Title = "Search2:Title"
+JournalTitle = "Search2:JournalTitle"
+Author = "Search2:Author:author,author2"
+Subject = "Search2:Subject:topic,genre,geographic,era"
+CallNumber = "Search2CN"
+ISN = "Search2:ISN:isbn,issn"
+Coordinate = "None"
+tag = "Tag"
+
+[Snippet_Captions]
+author2 = "Other Authors"
+contents = "Table of Contents"
+topic = "Subjects"
+container_title = "Journal Title"
+
+;[IndexShards]
+;Library Catalog = localhost:8983/solr/biblio
+;Website = localhost:8983/solr/website
+
+;[ShardPreferences]
+;showCheckboxes = true
+;defaultChecked[] = "Library Catalog"
+;defaultChecked[] = "Website"
+
+[StripFields]
+
+;[Views]
+;list = List
+;grid = Grid
+;visual = Visual
+
+[List]
+view=full
+
+[HiddenFilters]
+;institution = "MyInstitution"
+is_augustine = "1"
+
+[RawHiddenFilters]
+;0 = "format:\"Book\" OR format:\"Journal\""
+;1 = "language:\"English\" OR language:\"French\""
+
+[ConditionalHiddenFilters]
+;0 = "-conditionalFilter.MyUniversity|format:Book"
+;1 = "conditionalFilter.MyUniversity|format:Article"
+
+[Records]
+;deduplication = true
+;sources = alli,testsrc
+
+[MoreLikeThis]
+;useMoreLikeThisHandler = true
+;params = "qf=title,title_short,callnumber-label,topic,language,author,publishDate mintf=1 mindf=1";
+;count = 5
+
+[HomePage]
+;content[] = IlsStatusMonitor
+content[] = Home
+
+[API]
+;recordAccessPermission = access.api.Record
+;searchAccessPermission = access.api.Search
+;maxLimit = 100
+
+[SearchCache]
+;adapter = Memcached
+;options[servers] = "localhost:11211,otherhost:11211"
+;options[ttl] = 300
+;options[cache_dir] = "/tmp/search-cache"
+
+[Explain]
+;enabled = true
+;minPercent = 0
+;maxFields = -1
+;decimalPlaces = 2
+
+; ---------- facets.ini settings ----------
+
+[Results]
+fulltext_types        = "Fulltext Types"
+publishDate           = "adv_search_year"  ; share year string w/advanced search page
+is_open_access        = Open Access
+mediatype             = Mediatype
+format                = Format
+language              = Language
+ixtheo_notation_facet = "IxTheo Classification"
+dewey-hundreds        = "Call Number"
+topic_facet           = "Topic"
+;physical              = "Physical Format"
+; Use callnumber-first for LC call numbers, dewey-hundreds for Dewey Decimal:
+;callnumber-first      = "Call Number"
+;hierarchy_top_title   = Collections
+;key_word_chains       = "Keyword Chains"
+genre_facet           = Genre
+era_facet             = Era
+geographic_facet      = Region
+author_facet          = Author
+publisher_facet       = Publisher
+
+[ResultsTop]
+;topic_facet        = "Suggested Topics"
+
+[FacetLabels]
+labelSections[] = Advanced_Facets
+labelSections[] = HomePage_Facets
+labelSections[] = ResultsTop
+labelSections[] = Results
+labelSections[] = ExtraFacetLabels
+checkboxSections[] = CheckboxFacets
+
+[ExtraFacetLabels]
+long_lat = "Geographic Search"
+
+[SpecialFacets]
+dateRange[] = publishDate
+;fullDateRange[] = example_field_date
+;numericRange[] = example_field_str
+;genericRange[] = example_field_str
+;hierarchical[] = building
+;hierarchicalFacetSortOptions[building] = top
+;hierarchicalFacetDisplayStyles[format] = full
+;hierarchicalFacetSeparators[format] = " > "
+
+[CheckboxFacets]
+;edition:1st* = "First Edition"
+
+[Results_Settings]
+facet_limit = 30
+showMore[*] = 6
+showMoreInLightbox[*] = true
+lightboxLimit = 500
+top_rows = 2
+top_cols = 3
+;exclude = *
+orFacets = mediatype,format,language,ixtheo_notation_facet,geographic_facet,author_facet,publisher_facet,dewey-hundreds
+;collapsedFacets = *
+;sorted_by_index[] = building;
+;sorted_by_index[] = institution;
+suppress_count = fulltext_types
+
+; Enable JS feature to select multiple facets without reloading the result page
+; default : false (behaviour disabled)
+;multiFacetsSelection = true
+
+[Advanced_Facets]
+callnumber-first = "Call Number"
+language         = Language
+format           = Format
+;hierarchy_top_title   = Collections
+
+[Advanced_Settings]
+facet_limit      = 100
+orFacets = *
+delimiter = "{{{_:::_}}}"
+special_facets   = "illustrated,daterange"
+;translated_facets[] = institution
+;translated_facets[] = building
+translated_facets[] = format
+translated_facets[] = callnumber-first:CallNumberFirst
+translated_facets[] = fulltext_types
+translated_facets[] = is_open_access
+translated_facets[] = mediatype
+translated_facets[] = language
+;delimited_facets[] = author_id_str
+;delimited_facets[] = "author_id_str|:::"
+
+[HomePage_Facets]
+callnumber-first = "Call Number"
+language         = Language
+format           = Format
+;hierarchy_top_title   = Collections
+
+[HomePage_Facet_Settings]
+facet_limit      = 20
+
+[LegacyFields]
+
+[HideFacetValue]
+;format[] = "Book"

--- a/local/tuefind/instances/augustine/config/vufind/author-classification.ini
+++ b/local/tuefind/instances/augustine/config/vufind/author-classification.ini
@@ -1,0 +1,1 @@
+../../../../author-classification.ini

--- a/local/tuefind/instances/augustine/config/vufind/authority.ini
+++ b/local/tuefind/instances/augustine/config/vufind/authority.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/authority.ini

--- a/local/tuefind/instances/augustine/config/vufind/authsearchspecs.yaml
+++ b/local/tuefind/instances/augustine/config/vufind/authsearchspecs.yaml
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/authsearchspecs.yaml

--- a/local/tuefind/instances/augustine/config/vufind/config.ini
+++ b/local/tuefind/instances/augustine/config/vufind/config.ini
@@ -1,0 +1,2647 @@
+;
+; VuFind Configuration
+;
+
+; This section controls global system behavior and can usually be left unmodified.
+[System]
+; Change to false to take the system offline and show an unavailability message;
+; note that you can use the NoILS driver (in [Catalog] section below) to keep VuFind
+; up during ILS maintenance.
+available       = true
+; Change to true to see messages about the behavior of the system as part of the
+; output -- only for use when troubleshooting problems. See also the access.DebugMode
+; setting in permissions.ini to turn on debug using a GET parameter in the request.
+debug           = false
+; This setting should be set to false after auto-configuration is complete
+autoConfigure = false
+; This setting specifies a health check file location. If a health check file exists,
+; the getServerStatus AJAX call will return an error regardless of actual status
+; allowing the server to be disabled from a load-balancer.
+;healthCheckFile = /tmp/disable_vufind
+
+; This section will need to be customized for your installation
+[Site]
+; Base URL is normally auto-detected, but this setting is used when autodetection is
+; not possible (i.e. during sitemap generation at the command line).
+; see also configuration included from local_overrides included below
+url             = https://bible.ixtheo.de
+; Set to true if VuFind is behind a reverse proxy (typically Apache with mod_proxy),
+; make sure your reverse proxy sets the necessary headers.
+;reverse_proxy    = true
+email           = ixtheo@ub.uni-tuebingen.de
+; The title of your site, used in some messages and (by default) page <title> tags.
+; Including site title in page titles is recommended to improve browser tab
+; navigation for users with screen readers. However, if you wish to remove this from
+; titles or change the order/layout, you can customize the title_wrapper translation
+; in your language files to remove or relocate the %%siteTitle%% token.
+title           = "Index Augustinianus"
+; The separator used between page name and site name in the <title> tag of pages.
+titleSeparator = "::"
+;TueFind: Use this as browser title (if not set, "title" will be used)
+browser_title   = "IxAug"
+; This is the default theme for non-mobile devices (or all devices if mobile_theme
+; is disabled below). Available standard themes:
+;   bootstrap3 = HTML5 theme using Bootstrap 3 + jQuery libraries, with minimal styling
+;   bootprint3 = bootstrap3 theme with more attractive default styling applied
+;                (named after the earlier, now-deprecated blueprint theme)
+;   sandal     = bootstrap3 theme with a "flat" styling applied (a newer look
+;                than bootprint3).
+;   bootstrap5 = HTML5 theme using Bootstrap 5 with minimal styling (beta).
+;   sandal5    = Like sandal, but based on bootstrap5 (beta).
+theme            = augustine
+
+; Uncomment the following line to use a different default theme for mobile devices.
+; You may not wish to use this setting if you are using one of the Bootstrap-based
+; standard themes since they support responsive design.
+;mobile_theme    = mobile
+
+; Uncomment the following line to use a different theme for Admin module.
+;admin_theme     = sandal
+
+; Automatic asset minification and concatenation setting. When active, HeadScript
+; and HeadLink will concatenate and minify all viable files to reduce requests and
+; load times. This setting is off by default.
+;
+; This configuration takes the form of a semi-colon separated list of
+; environment:configuration pairs where "environment" is a possible APPLICATION_ENV
+; value (e.g. 'production' or 'development') or '*'/no prefix for all contexts.
+; Possible values for 'configuration' within each environment are 'js', 'css',
+; 'off'/false, 'on'/true/'*'. This allows global enabling/disabling of the pipeline
+; or separate configurations for different types of resources. Multiple configuration
+; values may be comma-separated -- e.g. 'js,css'.
+;
+; Example: "development:off; production:js,css"
+asset_pipeline = "js,css"
+
+; File size limit for inlining of css @import resources in kilobytes when the asset
+; pipeline is enabled (see above) for css files. Set to 0 to disable inlining. Note
+; that you will need to delete any css files from local/cache/public directory for
+; changes to this setting to take effect.
+;
+; N.B. The default here is 0 for compatibility with the content security policy.
+; A suggested non-zero value is 5, which improves performance by avoiding http
+; requests for small images, but any non-zero value requires that data: URIs are
+; added as allowed for images in contentsecuritypolicy.ini e.g. with the following
+; line:
+; img-src[] = "data:"
+asset_pipeline_max_css_import_size = 0
+
+; This is a comma-separated list of themes that may be accessed via the ?ui GET
+; parameter.  Each entry has two parts: the value used on the URL followed by the
+; actual theme name.  For example, http://library.myuniversity.edu/vufind?ui=theme1
+; would load the myTheme1 theme with the setting shown below.  Note that the values
+; of "standard" and "mobile" are reserved for the default and mobile themes defined
+; above.
+;alternate_themes = theme1:myTheme1,theme2:myTheme2
+
+; This is a comma-separated list of theme options that will be displayed to the user
+; as a drop-down.  Each entry has two parts: a value for the "ui" GET parameter and
+; an on-screen description.  "standard" refers to the "theme" setting above, "mobile"
+; refers to the "mobile_theme" setting, and all other values must be defined in
+; alternate_themes above.  When commented out, no drop-down theme list will display.
+;selectable_themes = "standard:Standard Theme,mobile:Mobile Theme"
+
+; Use the browser language setting to set the VuFind language.
+browserDetectLanguage = true
+language        = en    ; default -- more options available in [Languages] below.
+locale          = en_US
+; Comma-separated list of fallback languages to check when a translation is missing
+; from the active language. Default fallback languages are the default language above
+; and "en". Note that for changes to take effect, the language cache directory may
+; need to be cleared.
+;fallback_languages = "en-gb,de"
+
+; Set this to specify a default ISO 4217 currency code (used on the fines screen).
+; If omitted, the default currency for the locale above will be used.
+;defaultCurrency = USD
+; Find valid timezone values here:
+;   http://www.php.net/manual/en/timezones.php
+timezone        = "Europe/Berlin"
+; A string used to format user interface date strings using the PHP date() function
+; default is m-d-Y (MM-DD-YYYY 01-01-2010)
+displayDateFormat= "m-d-Y"
+; A string used to format user interface time strings using the PHP date() function
+; default is H:i (HH:MM 23:01)
+displayTimeFormat= "H:i"
+; The base VuFind URL will load this controller unless the user is logged in:
+defaultModule   = Search
+; When defaultModule is used, this action will be triggered (default = Home)
+;defaultAction = Home
+; The base VuFind URL will load this controller when the user is logged in:
+defaultLoggedInModule = Search
+; When defaultLoggedInModule is used, this action will be triggered (default = Home)
+;defaultLoggedInAction = Home
+; The search backend that VuFind will use in search boxes when nothing else is
+; specified (e.g. on user account pages, search history, etc.). Default = Solr
+;defaultSearchBackend = Solr
+; The route VuFind will send users to following a log out operation. Set to false
+; or omit to attempt to retain the user's current context after log out.
+;logOutRoute = home
+; Default tab to display when a record is viewed (see also RecordTabs.ini):
+defaultRecordTab = Holdings
+; Hide the holdings tab if no holdings are available from the ILS; note that this
+; feature requires your ILS driver to support the hasHoldings() method.
+hideHoldingsTabWhenEmpty = false
+; Whether to load the default tab through AJAX (which brings some performance
+; gain but breaks compatibility with non-Javascript-enabled browsers; off by default)
+;loadInitialTabWithAjax = true
+; The holdingsTemplate to use to display the ILS holdings (defaults to standard).
+; See the templates/RecordTab/holdingsils subdirectory of your theme for options.
+;holdingsTemplate = extended
+; This page will show by default when a user accesses the MyResearch module:
+defaultAccountPage = Favorites
+; Allow access to the Admin module? (See the access.AdminModule setting in
+; permissions.ini for more granular ways to restrict Admin access).
+admin_enabled = false
+; Show sidebar on the left side instead of right
+sidebarOnLeft = false
+; Invert the sidebarOnLeft setting for right-to-left languages?
+mirrorSidebarInRTL = true
+; Put search result thumbnails on the left (true) or right (false)
+resultThumbnailsOnLeft = true
+; Put favorites list thumbnails on the left (true) or right (false)
+listThumbnailsOnLeft = true
+; Put hold/checkedout/ILL/etc. item thumbnails on the left (true) or right (false)
+accountThumbnailsOnLeft = true
+; Show thumbnail on opposite side in right-to-left languages?
+mirrorThumbnailsRTL = true
+; Handle menu as an offcanvas slider at mobile sizes (in bootstrap3-based themes)
+offcanvas = false
+; Show (true) / Hide (false) Book Bag - Default is Hide.
+showBookBag = false
+; Set the maximum amount of items allowed in the Book Bag - Default is 100
+bookBagMaxSize = 100
+; Show individual add/remove bookbag buttons in search results? (Supersedes cart
+; checkboxes and bulk action buttons unless showBulkOptions is true).
+bookbagTogglesInSearch = true
+; Display bulk items (export, save, etc.) and checkboxes on search result screens?
+showBulkOptions = true
+; Should users be allowed to save searches in their accounts?
+allowSavedSearches = true
+; Some VuFind features can be made compatible with non-Javascript browsers at
+; a performance cost. By default, this compatibility is disabled, but it can
+; be turned on here. Note that even with this setting turned on, some features
+; still require Javascript; this simply improves compatibility for certain
+; features (such as display of hierarchies).
+nonJavascriptSupportEnabled = false
+; Generator value to display in an HTML header <meta> tag:
+generator = "VuFind 11.0.4"
+; Include server specific and private configurations
+; Overwrite instance specific configurations
+@include = 'local_overrides/augustine_site.conf'
+
+; This section allows you to configure the mechanism used for storing user
+; sessions.  Available types: File, Memcache, Database, Redis.
+; Some of the settings below only apply to specific session handlers;
+; such settings are named with an obvious prefix.  Non-prefixed settings
+; are global to all handlers.
+
+
+; The mandatory fields are collapse.field, expand.field, and expand.rows. It is better to set the same value for collapse.field and expand.field.
+; When the collapse.field is set, the feature is active.
+; If you want to override defaults / use specific features, please have a look at the Solr Documentation:
+; https://solr.apache.org/guide/solr/latest/query-guide/collapse-and-expand-results.html
+; collapse
+; mandatory fields are collapse.field, expand.field and expand.rows. The collapse.field is recommended to set the same value with expand.field
+[CollapseExpand]
+collapse.field = collapse_expand
+;collapse.min =
+;collapse.max =
+;collapse.sort =
+;collapse.nullPolicy = ignore
+;collapse.hint =
+;collapse.size = 100000
+;collapse.collectElevatedDocsWhenCollapsing = true
+
+expand.field = collapse_expand
+expand.rows = 500
+;expand.sort = score desc
+;expand.q =
+;expand.fq =
+;expand.nullGroup = false
+
+[Session]
+type                        = File
+lifetime                    = 2592000 ; Session lasts for 30 days, see privacy page
+; Should stored session data be encrypted?
+secure = false
+; Keep-alive interval in seconds. When set to a positive value, the session is kept
+; alive with a JavaScript call as long as a VuFind page is open in the browser.
+; Default is 0 (disabled). When keep-alive is enabled, session lifetime above can be
+; reduced to e.g. 600.
+;keepAlive = 60
+;file_save_path              = /tmp/vufind_sessions
+;memcache_host               = localhost
+;memcache_port               = 11211
+;memcache_connection_timeout = 1
+; The name of the PHP client library to use for connecting to Memcache (can be either
+; "Memcache" or "Memcached"); default is "Memcache". Note that if you change from one
+; library to another, you should flush your cache to avoid problems caused by
+; inconsistencies in data encoding between the two libraries.
+;memcache_client             = Memcache
+;
+; Settings related to Redis-based sessions; default values are listed below
+;redis_host               = localhost
+;redis_port               = 6379
+;redis_connection_timeout = 0.5
+;redis_db                 = 0
+;redis_user               = username (optional)
+;redis_auth               = some_secret_password
+;redis_version            = 3
+;redis_standalone         = true
+
+; This section controls how VuFind creates cookies (to store session IDs, bookbag
+; contents, theme/language settings, etc.)
+[Cookies]
+; In case there are multiple VuFind instances on the same server and they should not
+; share cookies/sessions, this option can be enabled to limit the session to the
+; current path. Default is false, which will place cookies at the root directory.
+;limit_by_path = true
+; If VuFind is only accessed via HTTPS, this setting can be enabled to disallow
+; the browser from ever sending cookies over an unencrypted connection (i.e.
+; before being redirected to HTTPS). Default is false.
+only_secure = true
+; Whether to set cookies set by the server (apart from cart function) "HTTP only" so
+; that they cannot be accessed by scripts. Default is true.
+;http_only = false
+; Set the domain used for cookies (sometimes useful for sharing the cookies across
+; subdomains); by default, cookies will be restricted to the current hostname.
+;domain = ".example.edu"
+; This sets the session cookie's name. Comment this out to use the default
+; PHP_SESS_ID value. If running multiple versions of VuFind (or multiple PHP
+; applications) on the same host, it is strongly recommended to give each a
+; different session_name setting to avoid data contamination.
+session_name = AUGUSTINE_SESSION
+; Set the SameSite attribute used for cookies. Default is Lax. See e.g.
+; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite for
+; more information
+;sameSite = "Lax"
+; Whether to ask for cookie consent (required e.g. for GDPR compliance). Default is
+; false. See also CookieConsent.yaml for cookie categories and other settings.
+consent = true
+; Categories to enable for cookie consent. This is a comma-separated list of
+; categories defined in CookieConsent.yaml. Default is "essential".
+consentCategories = "essential,matomo"
+; Cookie consent revision. If you change the categories or do any other major changes
+; in CookieConsent.yaml, you will need to increase revision as well so that users get
+; prompted for consent.
+;consentRevision = 0
+
+; Please set the ILS that VuFind will interact with.
+;
+; Available drivers:
+;   - Aleph
+;   - Alma
+;   - Amicus
+;   - ComposedDriver (combining multiple drivers)
+;   - DAIA (using either XML or JSON API)
+;   - Demo (fake ILS driver returning complex responses)
+;   - Evergreen
+;   - Folio
+;   - GeniePlus
+;   - Horizon (basic database access only)
+;   - HorizonXMLAPI (more features via API)
+;   - Innovative (for INNOPAC; see also SierraRest)
+;   - Koha (basic database access only)
+;   - KohaILSDI (more features via ILS-DI API)
+;   - KohaRest (the most feature-complete Koha driver using Koha's REST API. Requires
+;     at least Koha 20.05 and the koha-plugin-rest-di extension found at:
+;     https://github.com/natlibfi/koha-plugin-rest-di)
+;   - MultiBackend (to chain together multiple drivers in a consortial setting)
+;   - NewGenLib
+;   - NoILS (for users with no ILS, or to disable ILS features during maintenance),
+;   - PAIA
+;   - Polaris
+;   - Sample (fake ILS driver returning bare-minimum data)
+;   - SierraRest (accesses Sierra via REST API)
+;   - Symphony (uses native SirsiDynix APIs)
+;   - Unicorn (also applies to Symphony; requires installation of connector found at:
+;     http://code.google.com/p/vufind-unicorn/)
+;   - Virtua
+;   - Voyager (database access only; for Voyager 6+)
+;   - VoyagerRestful (for Voyager 7+ w/ RESTful web services)
+;   - XCNCIP2 (for XC NCIP Tookit v2.x)
+;
+; If you haven't set up your ILS yet, two fake drivers are available for testing
+; purposes. "Sample" is fast but does very little; "Demo" simulates more
+; functionality of a real ILS but may slow down your system by performing extra
+; searches. If you don't plan to use an ILS, the NoILS driver is your best option.
+;
+; Note: Enabling most of the features in this section will only work if you use an
+; ILS driver that supports them; not all drivers support holds/renewals.
+[Catalog]
+driver          = NoILS
+
+; If true, the user will be presented with a login form for entering ILS credentials
+; when attempting to access ILS functionality without working cached credentials.
+; If false, the user will instead see an error screen. You should use the false value
+; here when the user's ILS credentials are automatically loaded into the database via
+; [Authentication] and related configuration, and you never expect a user to manually
+; provide these details.
+;
+; Note: if you disable user login, this can also have implications for the
+; library_cards setting (see below).
+allowUserLogin = true
+
+; If true (default), any ILS credentials stored with the user are checked up-front
+; when the user logs in to VuFind. If the credentials don't work, they're cleared,
+; and the user will be prompted for new credentials when accessing a page that
+; needs them. This setting is ignored if allowUserLogin is false.
+;checkILSCredentialsOnLogin = true
+
+; ILS data cache life time in seconds. The cache is used to avoid repeating
+; requests too often (but often enough to not use stale data).
+; Default is 60 seconds. Set to 0 to disable caching.
+; * can be used to set the default for all cacheable functions (patronLogin,
+; getProxiedUsers, getProxyingUsers or getPurchaseHistory):
+;cacheLifeTime[*] = 60
+; Default cache life time can be overridden for any cacheable function:
+;cacheLifeTime[getProxiedUsers] = 300
+
+; loadNoILSOnFailure - Whether or not to load the NoILS driver if the main driver fails
+loadNoILSOnFailure = false
+
+; healthCheckId - When performing ILS health checks (see the IlsStatusMonitor block
+; described in searches.ini for more details), VuFind will look up the status of a
+; bibliographic record and ensure the response is well-formed. By default, it uses
+; a bibliographic record ID of "1". If your ILS does not accept "1" as a valid
+; identifier, you can specify a different health check record ID here.
+;healthCheckId = 12345
+
+; List of search backends that contain records from your ILS (defaults to Solr
+; unless set otherwise). You can set ilsBackends = false to disable ILS status
+; loading entirely.
+;ilsBackends[] = Solr
+
+; This setting determines how and when hold / recall links are displayed.
+; Legal values:
+; - all (Show links for all items - Place Hold for Available Items and Place Recall
+;   for unavailable items)
+; - availability (Only show recall links if ALL items on bib are currently
+;   unavailable)
+; - disabled (Never show hold/recall links)
+; - driver (Use ILS driver to determine which items may be held/recalled; best option
+;   if available, but not supported by all drivers)
+; - holds (Only show links for available items)
+; - recalls (Only show links for unavailable items)
+; default is "all"
+holds_mode = "all"
+
+; Set this to true if you want to allow your ILS driver to override your holds_mode
+; setting on a record-by-record basis; this may be useful for local customizations,
+; but in most cases you should leave this setting unchanged.  Overrides are ignored
+; for mode settings of "driver" or "disabled."
+allow_holds_override = false
+
+; Determines if holds can be cancelled or not. Options are true or false.
+; default is false
+cancel_holds_enabled = false
+
+; Determines if storage retrieval requests can be cancelled or not.
+; Options are true or false.
+; default is false
+cancel_storage_retrieval_requests_enabled = false
+
+; Determines if ILL requests can be cancelled or not.
+; Options are true or false.
+; default is false
+cancel_ill_requests_enabled = false
+
+; Determines if item can be renewed or not. Options are true or false.
+; default is false
+renewals_enabled = false
+
+; Determines if title level holds are displayed or not.
+; Legal values:
+; - disabled (Never show title Holds - Default)
+; - always (Always show title Holds)
+; - availability (Only show title holds if ALL items on bib are currently
+;   unavailable)
+; - driver (Use ILS driver to determine which items may be held/recalled; best option
+;   if available, but not supported by all drivers)
+title_level_holds_mode = "disabled"
+
+; Determines how holdings are grouped in the record display, using fields from
+; the item information provided by the ILS driver.
+;
+; Most commonly-used values:
+; - holdings_id,location (Use holdings record id if available, location name as
+;   secondary - Default)
+; - location (Use location name)
+;
+; See https://vufind.org/wiki/development:plugins:ils_drivers#getholding for
+; more options (though not every ILS driver supports every possible value).
+;
+; Note that there may also be driver-specific values outside of the specification,
+; such as:
+; - item_agency_id (XCNCIP2 driver's Agency ID, which may be useful in consortial
+;   environments)
+;
+; You may use multiple group keys (delimited by comma), e.g.,
+; - item_agency_id,location
+;holdings_grouping = holdings_id,location
+
+; Text fields such as holdings_notes gathered from items to be displayed in each
+; holdings group in the display order.
+; The default list is 'holdings_notes', 'summary', 'supplements' and 'indexes'. The
+; deprecated field 'notes' is used as an alias for 'holdings_notes'.
+; Note that displayed information depends on what the ILS driver returns.
+;holdings_text_fields[] = 'holdings_notes'
+;holdings_text_fields[] = 'summary'
+
+; Whether support for multiple library cards is enabled. Default is false.
+;
+; Note: to create library cards through a manual form, users will require
+; the allowUserLogin setting (see above) to be enabled as well.
+;library_cards = true
+
+; Whether support for connecting multiple library cards via authentication is
+; enabled. This is currently only supported for Shibboleth. Default is false.
+; See https://vufind.org/wiki/configuration:shibboleth:library_cards for details.
+;auth_based_library_cards = true
+
+; The number of checked out items to display per page; 0 for no limit (may cause
+; memory problems for users with huge numbers of items). Default = 50.
+;checked_out_page_size = 50
+
+; The number of historic loans to display per page; 0 for no limit (may cause
+; memory problems for users with a large number of historic loans). Default = 50
+;historic_loan_page_size = 50
+
+; Whether to display the item barcode for each loan. Default is false.
+;display_checked_out_item_barcode = true
+
+; Whether to display items without barcodes in the Holdings tab. Prior to VuFind
+; 9.0, hiding items without barcodes was VuFind's default behavior. The current
+; default value is true -- to always display ALL items.
+; If you need to apply more complex filtering rules to Holdings display, you
+; can extend/override the VuFind\View\Helper\Root\Holdings::holdingIsVisible method.
+;display_items_without_barcodes = true
+
+; This section controls features related to user accounts
+[Account]
+; Allow the user to set a home library through the Profile screen, which will
+; override ILS-provided default pickup locations throughout the system.
+set_home_library = true
+
+; Allow the user to "subscribe" to search history entries in order to receive
+; email notifications of new search results.
+schedule_searches = false
+
+; Should we always send a scheduled search email the first time we run notices
+; after a user has subscribed (true), or should we only send an email when there
+; is actually something new (false, default)
+force_first_scheduled_email = false
+
+; When schedule_searches is set to true, you can customize the schedule frequencies
+; here -- just use the number of days between notifications in the brackets. Labels
+; will be run through the translator.
+;scheduled_search_frequencies[0] = schedule_none
+;scheduled_search_frequencies[1] = schedule_daily
+;scheduled_search_frequencies[7] = schedule_weekly
+
+; This section allows you to determine how the users will authenticate.
+[Authentication]
+; You can authenticate using one or more of the following methods:
+; - AlmaDatabase (combination of VuFind database and Alma account; see also Alma.ini)
+; - CAS (see also [CAS] section)
+; - Database: VuFind's internal user database
+; - Email (see notes below)
+; - Facebook (see also [Facebook] section)
+; - ILS: the local ILS
+; - LDAP: an LDAP directory (see also [LDAP] section)
+; - MultiILS: multiple ILSes (see also MultiBackend.ini)
+; - OpenIDConnect: Open ID Connect (see also OpenIDConnectClient.ini)
+; - PasswordAccess: a hard-coded list of access passwords (see also [PasswordAccess] section)
+; - Shibboleth (see also [Shibboleth] section)
+; - SimulatedSSO: simulated single sign-on for testing/development (see SimulatedSSO.ini)
+; - SIP2 (see also [SIP2] section)
+; - some combination of the above (via the MultiAuth or ChoiceAuth options).
+;
+; The Email method is special; it is intended to be used through ChoiceAuth in
+; combination with Database authentication (or any other method that reliably stores
+; the user's email address) to make it possible to log in by receiving an
+; authentication link at the email address stored in VuFind's database. Email is
+; also supported as the primary authentication mechanism for some ILS drivers (e.g.
+; Alma). In these cases, ChoiceAuth is not needed, and ILS should be configured as
+; the Authentication method; see the ILS driver's configuration for possible options.
+;
+; Also note that the Email method stores hashes in your database's auth_hash table.
+; You should run the "php $VUFIND_HOME/public/index.php util expire_auth_hashes"
+; utility periodically to clean out old data in this table.
+method = Database
+
+; This setting only applies when method is set to ILS.  It determines which
+; field of the ILS driver's patronLogin() return array is used as the username
+; in VuFind's user database.  If commented out, it defaults to cat_username
+; (the recommended setting in most situations).
+;ILS_username_field = cat_username
+
+; Whether or not to hide the Login Options; note that even when this is set to
+; false, ILS driver settings may be used to conditionally hide the login. See
+; hideLogin in the [Settings] section of NoILS.ini for an example.
+hideLogin = false
+
+; When set to true, uses AJAX calls to annotate the account menu with
+; notifications (overdue items, total fines, etc.)
+enableAjax = false
+
+; When set to true, replicates the account menu as a drop-down next to the
+; account link in the header.
+enableDropdown = false
+
+; Setting this to false will turn off password hashing and store user passwords
+; in plain text, which is NOT RECOMMENDED, but may be useful if you are in the
+; process of migrating data from a very old VuFind release that predates password
+; hashing. DO NOT CHANGE under other circumstances. Also note that this setting
+; only applies when method = Database or AlmaDatabase above.
+hash_passwords = true
+
+; Allow users to recover passwords via email (if supported by Auth method)
+; You can set the subject of recovery emails in your
+; language files under the term "recovery_email_subject"
+recover_password = true
+; Time (seconds) before another recovery attempt can be made
+recover_interval      = 60
+; Length of time before a recovery hash can no longer be used (expires)
+; Default: Two weeks
+recover_hash_lifetime = 1209600
+
+; Allow users to set change their email address (if supported by Auth method).
+; When turning this on, it is also strongly recommended to turn on verify_email
+; below.
+change_email = true
+
+; Allow users to set change their passwords (if supported by Auth method)
+change_password = true
+
+; Force users to verify their email address before being able to log in
+; (only if method=Database) or make changes to it (if change_email=true).
+; If you wish to customize the email messages used by the system, see the
+; translation strings starting with verify and change_notification, as well as
+; the notify-email-change.phtml and verify-email.phtml Email templates.
+verify_email = true
+
+; Set this to false if you would like to store catalog passwords in plain text
+encrypt_ils_password = false
+
+; This is the key used to encrypt and decrypt catalog passwords.  This must be
+; filled in with a random string value when encrypt_ils_passwords is set to true.
+; Note: aes requires a key exactly 32 characters long.
+; 32 chars ->        "--------------------------------"
+ils_encryption_key = false
+
+; This is the algorithm used to encrypt and decrypt catalog passwords.
+; A symmetrical encryption algorithm must be used.
+; You can use openssl_get_cipher_methods() to see available options on your system.
+; Common choices: blowfish (deprecated -- do not use), aes (recommended), cast, sm4
+; If you want to convert from one algorithm to another, run this from $VUFIND_HOME:
+;   php public/index.php util switch_db_hash new_algorithm new_key
+;ils_encryption_algo = "aes"
+
+; This setting may optionally be uncommented to restrict the email domain(s) from
+; which users are allowed to register when using the Database or AlmaDatabase method.
+;legal_domains[] = "myuniversity.edu"
+;legal_domains[] = "mail.myuniversity.edu"
+
+; Specify default minimum and maximum new username length (Auth method may override
+; this).
+;minimum_username_length = 3
+;maximum_username_length = 32
+; Specify default limit of accepted characters in the username. Allowed values
+; are "numeric", "alphanumeric" or a regular expression.
+; The following default requires the username to consist of printable characters
+; allowed in email addresses (i.e. !#$%&'*+-/=?^_`{|}~) and letters and decimal
+; numbers in any script (see
+; https://www.php.net/manual/en/regexp.reference.unicode.php for more information):
+username_pattern = "([\\x21\\x23-\\x2B\\x2D-\\x2F\\x3D\\x3F\\x40\\x5E-\\x60\\x7B-\\x7E\\p{L}\\p{Nd}]+)"
+; Specify default hint about what the username may contain when using a regexp
+; pattern. May be text or a translation key. The "numeric" and "alphanumeric"
+; patterns have translated default hints.
+username_hint = username_only_letters_numbers_and_basic_punctuation
+
+; Specify default minimum and maximum password length (Auth method may override
+; this).
+;minimum_password_length = 4
+;maximum_password_length = 32
+; Specify default limit of accepted characters in the password. Allowed values
+; are "numeric", "alphanumeric" or a regular expression
+;password_pattern = "(?=.*\d)(?=.*[a-z])(?=.*[A-Z])"
+; Specify default hint about what the password may contain when using a regexp
+; pattern. May be text or a translation key. The "numeric" and "alphanumeric"
+; patterns have translated default hints.
+;password_hint = "Include both upper and lowercase letters and at least one number."
+
+; Uncomment this line to switch on "privacy mode" in which no user information
+; will be stored in the database. Note that this is incompatible with social
+; features, password resets, and many other features. It is not recommended for
+; use with "Database" or "AlmaDatabase" authentication, since the user will be
+; forced to create a new account upon every login.
+;privacy = true
+
+; Allow a user to delete their account. Default is false.
+account_deletion = true
+; Whether comments added by a user are deleted when they remove their account.
+; Default is true.
+;delete_comments_with_user = false
+; Whether ratings added by a user are deleted when they remove their account.
+; Default is true.
+;delete_ratings_with_user = false
+
+; "Remember me" functionality for listed login methods. If the user chooses to save
+; the login, a login token cookie and a database entry will be created.
+; The implementation is based on Improved Persistent Login Cookie Best Practice, see
+; https://gist.github.com/oleg-andreyev/9dcef18ca3687e12a071648c1abff782
+; User's browser information is stored with the login token. This requires an up to
+; date browscap cache. The browscap cache can be updated in the Maintenance section
+; of the admin UI or by using the util/browscap command line utility. If you use the
+; command line utility, you will need to ensure that the user of the web server has
+; read and write access to the cache directory and its contents as well.
+; If you use cookie consent, ensure that the loginToken cookie is included (look for
+; {{vufind_login_token_cookie_name}} in CookieConsent.yaml).
+;persistent_login = "database,multiils"
+
+; Persistent login token lifetime in days
+;persistent_login_lifetime = 60
+
+; Whether to send email warnings about suspicious logins. Default is true.
+;send_login_warnings = true
+
+; Whether to use a more lenient token rotation to avoid cookie issues with Safari,
+; which sometimes fails to maintain cookies across sessions. Default is true.
+;lenient_token_rotation = true
+
+; Subject for the email sent after a suspicious login has been detected.
+; Default email subject will be the translation for
+; "persistent_login_warning_email_subject" and any custom value used here
+; will also be run through the translator.
+;persistent_login_warning_email_subject = "%%title%%: Invalid login attempt detected"
+
+; See the comments in library/VF/Auth/MultiAuth.php for full details
+; on using multiple authentication methods.  Note that MultiAuth assumes login
+; with username and password, so some methods (i.e. Shibboleth) may not be
+; compatible.
+;[MultiAuth]
+;method_order   = ILS,LDAP
+;filters = "username:trim,password:trim"
+
+; Present two auth options on the login screen. Each choice given must also be
+; configured in its relevant section. (The code should allow for more than 2
+; choices, but styling would need to be expanded / modified)
+;
+; WARNING! This module does not account for the possibility that the auth
+; choices you present may return different usernames. You would want a user to
+; be able to log in via any method and see the same account. To make sure that
+; is the case, you should ensure that the usernames given by the authentication
+; methods themselves are the same for any given user.
+;[ChoiceAuth]
+;choice_order = Shibboleth,Database
+
+; This section defines the location/behavior of the Solr index and requires no
+; changes for most installations
+[Index]
+; url can also be an array of servers. If so, VuFind will try the servers one by one
+; until one can be reached. This is only useful for advanced fault-tolerant Solr
+; installations.
+url             = http://localhost:8983/solr
+; Default bibliographic record index name (core or collection)
+default_core    = biblio
+; Default authority record index name (core or collection)
+default_authority_core = authority
+; This setting needs to match the <maxBooleanClauses> setting in your solrconfig.xml
+; file; when VuFind has to look up large numbers of records using ID values, it may
+; have to restrict the size of its result set based on this limitation.
+maxBooleanClauses = 1024
+; This is the timeout in seconds when communicating with the Solr server.
+timeout = 30
+; This is the Dismax handler to use if nothing is specified in searchspecs.yaml.
+; You can choose dismax for standard Dismax (the default) or edismax for Extended
+; Dismax, or you can configure your own custom handler in solrconfig.xml.
+default_dismax_handler = edismax
+; This is the number of records to retrieve in a batch e.g. when building a record
+; hierarchy. A higher number results in fewer round-trips but may increase Solr's
+; memory usage. Default is 1000. Set to false to disable use of cursors in retrieval
+; (which is only necessary if your local custom code leverages Solr features which
+; are incompatible with cursorMark usage).
+;cursor_batch_size = 1000
+; This limits the number of records to retrieve in a batch e.g. when retrieving
+; records for a list. Default is 100 which should be a good number to avoid
+; memory problems.
+;record_batch_size = 100
+
+; Enable/Disable searching reserves using the "reserves" Solr index.  When enabling
+; this feature, you need to run the util/index_reserves.php script to populate the
+; new index.
+[Reserves]
+search_enabled  = false
+
+; This section requires no changes for most installations; if your SMTP server
+; requires authentication, you can fill in a username and password below.
+[Mail]
+host            = localhost
+port            = 25
+;username       = user
+;password       = pass
+; The server name to report to the upstream mail server when sending mail.
+;name = vufind.myuniversity.edu
+; If a login is required you can define which protocol to use for securing the
+; connection. If no explicit protocol ('tls' or 'ssl') is configured, a protocol
+; based on the configured port is chosen (587 -> tls, 487 -> ssl).
+;secure         = tls
+; This setting enforces a limit (in seconds) on the lifetime of an SMTP
+; connection, which can be useful when sending batches of emails, since it can
+; help avoid errors caused by server timeouts. Comment out the setting to disable
+; the limit.
+connection_time_limit = 60
+; Uncomment this setting to disable outbound mail but simulate success; this
+; is useful for interface testing but should never be used in production!
+;testOnly = true
+; Set to a file path writable by VuFind to log email messages into that file;
+; primarily intended for testing/debugging purposes.
+;message_log = /tmp/emails.log
+; The action to email records and searches may be "enabled", "disabled" or "require_login"
+; (default = "require_login")
+; If set to "enabled", users can send anonymous emails; If set to "require_login",
+; they must log in first; "disabled" disables the action completely
+email_action = require_login
+; Should we put the logged-in user's address in the "from" field by default?
+user_email_in_from = true
+; Should we put the logged-in user's address in the "to" field by default?
+user_email_in_to = true
+; Should the user be allowed to edit email subject lines?
+user_editable_subjects = false
+; How many recipients is the user allowed to specify? (use 0 for no limit)
+maximum_recipients = 10
+; Populate the "from" field with this value if user_email_in_from is false and/or no
+; user is logged in:
+;default_from = "no-reply@myuniversity.edu"
+; Should we hide the "from" field in email forms? If no from field is visible, emails
+; will be sent based on user_email_in_from and default_from above, with the email
+; setting from the [Site] section used as a last resort.
+disable_from = true
+; From field override. Setting this allows keeping the "from" field in email forms
+; but will only use it as a reply-to address. The address defined here is used as the
+; actual "from" address.
+; Note: If a feature explicitly sets a different reply-to address (for example,
+; Feedback forms), the original from address will NOT override that reply-to value.
+;override_from = "no-reply@myuniversity.edu"
+
+; Being a special case of mail message, sending record results via SMS ("Text this")
+; may be "enabled" or "disabled" ("enabled" by default).
+; Should you choose to leave it enabled, see also sms.ini for further
+; configuration options.
+sms = disabled
+
+; Set this value to "database" to shorten links sent via email/SMS and
+; store its path in the database (default "none").
+url_shortener = database
+
+; Which method to use for generating the short link key. Options:
+; - base62: Base62-encode the database row ID (insecure, but makes very short URLs)
+; - md5: Create a salted MD5 hash of the URL (DEFAULT: more private, but also longer)
+; ...or any hash algorithm supported by PHP's hash() function.
+url_shortener_key_type = base62
+
+; Which redirect mechanism to use when shortlinks are resolved.
+; threshold:1000 (default) : If the URL is shorter than the given size, HTTP is used, else HTML.
+; html                     : HTML meta redirect after 3 seconds with infobox.
+; http                     : Use HTTP location header for redirects.
+;                            May cause problems if the HTTP header is longer than 8192 bytes
+;                            due to long URL's.
+url_shortener_redirect_method = html
+
+; This section needs to be changed to match your database connection information
+[Database]
+; Connection string format is [platform]://[username]:[password]@[host]:[port]/[db]
+; where:
+; [platform/driver] = database platform (mysql, oci8 or pgsql)
+; [username] = username for connection
+; [password] = password for connection (optional)
+; [host] = host of database server
+; [port] = port of database server (optional)
+; [db] = database name
+; For more granular configuration, comment out the database setting and use the individual parameters below.
+database          = mysql://vufind:test@localhost/vufind
+;database_driver = "mysql"
+;database_username = "notroot"
+;database_password = "password"
+; database_password_file will be used in priority over database_password
+;database_password_file = "/path/to/secret"
+;database_host = "localhost"
+;database_port = "3306"
+;database_name = "vufind"
+
+; Should SSL be enabled on connections? (Currently only supported for MySQL).
+; IMPORTANT: when using Linux, if your database connection string above uses
+; "localhost", MySQL will automatically use a Unix socket connection. To force
+; an SSL connection, change "localhost" to the IP address (e.g. "127.0.0.1").
+use_ssl = false
+
+; When use_ssl above is true, the SSL certificate used by MySQL will not be
+; verified by default. This is usually a self-signed certificate that cannot be
+; easily verified. Skipping verification will not prevent traffic from being
+; securely encrypted, it simply means that you trust the validity of the
+; certificate being used by your server. If you do switch this to true in order
+; to force certificate verification, additional configuration may be needed to
+; successfully connect and ensure actual certificate verification occurs.
+; For PHP, you should fill in the security-related settings in extra_options
+; below; for Java (used by the MARC import tool), see the "Connecting Securely
+; Using SSL" section of the Connector/J manual for details.
+verify_server_certificate = false
+
+; This setting can be used to send additional options to the Laminas DB adapter.
+; This is useful for advanced features unsupported by settings above, such as
+; detailed SSL security configuration.
+;extra_options[client_key] = "/path/to/key"
+;extra_options[client_cert] = "/path/to/cert"
+;extra_options[ca_cert] = "/path/to/ca_cert"
+;extra_options[ca_path] = "/path/to/ca"
+
+; If your database (e.g. PostgreSQL) uses a schema, you can set it here:
+;schema = schema_name
+
+; The character set of the database -- utf8 and utf8mb4 are currently the only
+; supported values, and utf8mb4 is the default if no value is set here. If you have
+; a legacy VuFind 1.x database encoded in latin1, please upgrade it to utf8 using
+; VuFind 7.x or earlier.
+;charset = utf8
+
+@include = 'local_overrides/database.conf'
+
+; Reduce access to a set of single passwords
+; This is only used when Authentication method is PasswordAccess. See above.
+; Recommended to be used in conjunction with very restricted permissions.ini settings
+; and with most social settings disabled
+;[PasswordAccess]
+; access_user is a map of users to passwords
+; entering a correct password will login as that user
+;access_user[user] = password
+;access_user[admin] = superpassword
+
+; LDAP is optional.  This section only needs to exist if the
+; Authentication Method is set to LDAP.  When LDAP is active,
+; host, port, basedn and username are required.
+;[LDAP]
+; Prefix the host with ldaps:// to use LDAPS; omit the prefix for standard
+; LDAP with TLS.
+;host            = ldap.myuniversity.edu
+;port            = 389       ; LDAPS usually uses port 636 instead
+; By default, when you use regular LDAP (not LDAPS), VuFind uses TLS security.
+; You can set disable_tls to true to bypass TLS if your server does not support
+; it. Note that this setting is ignored if you use ldaps:// in the host setting.
+;disable_tls     = false
+;basedn          = "o=myuniversity.edu"
+;username        = uid
+; separator string for mapping multi-valued ldap-fields to a user attribute
+; if no separator is given, only the first value is mapped to the given attribute
+;separator = ';'
+; Optional settings to map fields in your LDAP schema to fields in the user table
+; in VuFind's database -- the more you fill in, the more data will be imported
+; from LDAP into VuFind:
+;firstname       = givenname
+;lastname        = sn
+;email           = mail
+;cat_username    =
+;cat_password    =
+;college         = studentcollege
+;major           = studentmajor
+; If you need to bind to LDAP with a particular account before
+; it can be searched, you can enter the necessary credentials
+; here.  If this extra security measure is not needed, leave
+; these settings commented out.
+;bind_username   = "uid=username o=myuniversity.edu"
+;bind_password   = password
+
+; SIP2 is optional.  This section only needs to exist if the
+; Authentication Method is set to SIP2.
+;[SIP2]
+;host            = ils.myuniversity.edu
+;port            = 6002
+
+; Shibboleth is optional.  This section only needs to exist if the
+; Authentication Method is set to Shibboleth. Be sure to set up authorization
+; logic in the permissions.ini file to filter users by Shibboleth attributes.
+;[Shibboleth]
+; Server param with the identity provider entityID if a Shibboleth session exists.
+; If omitted, Shib-Identity-Provider is used.
+;idpserverparam = Shib-Identity-Provider
+; Optional: Session ID parameter for SAML2 single logout support. If omitted, single
+; logout support is disabled. Note that if SLO support is enabled, Shibboleth session
+; ID's are tracked in external_session table which may need to be cleaned up with the
+; util/expire_external_sessions command line utility. See
+; https://vufind.org/wiki/configuration:shibboleth for more information on how
+; to configure the single logout support.
+;session_id = Shib-Session-ID
+; Check for expired session - user is automatically logged out when Shibboleth
+; session is not present (default = true if unset); note that expiration check
+; also requires session_id to be set above.
+;checkExpiredSession = false
+; Optional: you may set attribute names and values to be used as a filter;
+; users will only be logged into VuFind if they match these filters.
+;userattribute_1       = entitlement
+;userattribute_value_1 = urn:mace:dir:entitlement:common-lib-terms
+;userattribute_2       = unscoped-affiliation
+;userattribute_value_2 = member
+; Set to true when shibboleth attributes must be read from headers instead of
+; environment variables - for example if you use proxy server and shibboleth is
+; running on proxy side. In that case you should protect against header spoofing:
+; see https://wiki.shibboleth.net/confluence/display/SP3/SpoofChecking for details
+;use_headers           = false
+; Required: the attribute Shibboleth uses to uniquely identify users.
+;username              = persistent-id
+; Required: Shibboleth login URL.
+;login                 = https://shib.myuniversity.edu/Shibboleth.sso/Login
+; Optional: Shibboleth logout URL.
+;logout                = https://shib.myuniversity.edu/Shibboleth.sso/Logout
+; Optional: URL to forward to after Shibboleth login (if omitted,
+; defaultLoggedInModule from [Site] section will be used).
+;target                = https://shib.myuniversity.edu/vufind/MyResearch/Home
+; Optional: provider_id (entityId) parameter to pass along to Shibboleth login.
+;provider_id           = https://idp.example.edu/shibboleth-idp
+; Some or all of the following entries may be uncommented to map Shibboleth
+; attributes to user database columns:
+;cat_username = HTTP_ALEPH_ID
+;cat_password = HTTP_CAT_PASSWORD
+;email = HTTP_MAIL
+;firstname = HTTP_FIRST_NAME
+;lastname = HTTP_LAST_NAME
+;college = HTTP_COLLEGE
+;major = HTTP_MAJOR
+;home_library = HTTP_HOME_LIBRARY
+; Enable if you want to override mapping or required attributes for specific IdP
+; in Shibboleth.ini
+;allow_configuration_override = true
+
+; CAS is optional.  This section only needs to exist if the
+; Authentication Method is set to CAS.
+;[CAS]
+
+; Optional: the attribute CAS uses to uniquely identify users. (Omit to use
+; native CAS username instead of an attribute-based value).
+;username              = uid
+
+; Required: CAS Hostname.
+;server                = cas.myuniversity.edu
+
+; Required: CAS port.
+;port                 = 443
+
+; Required: CAS context.
+;context                 = /cas
+
+; Required: CAS Certificate Path. (Set to false to bypass authentication;
+; BYPASSING AUTHENTICATION IS *NOT* RECOMMENDED IN PRODUCTION).
+;CACert = /etc/pki/cert/cert.crt
+
+; Required: CAS login URL.
+;login                 = https://cas.myuniversity.edu/cas/login
+
+; Required: CAS logout URL.
+;logout                = https://cas.myuniversity.edu/cas/logout
+
+; Optional : CAS client base URL. If omitted, [Site][url] will be used
+;service_base_url[]    = "https://vufind.myuniversity.edu"
+;service_base_url[]    = "http://vufind.myuniversity.edu"
+
+; Optional: CAS logging, forwarded to [Logging]
+;debug                 = false
+
+; Optional: URL to forward to after CAS login (if omitted,
+; defaultLoggedInModule from [Site] section will be used).
+;target                = http://lib.myuniversity.edu/vufind/MyResearch/Home
+
+; Optional: protocol to follow (legal values include CAS_VERSION_1_0,
+; CAS_VERSION_2_0, CAS_VERSION_3_0 and SAML_VERSION_1_1; default is
+; SAML_VERSION_1_1)
+;protocol = SAML_VERSION_1_1
+
+; Some or all of the following entries may be uncommented to map CAS
+; attributes to user database columns:
+;cat_username = acctSyncUserID
+;cat_password = catPassword
+;email = mail
+;firstname = givenName
+;lastname = sn
+;college = college
+;major = major1
+;home_library = library
+
+; Facebook may be used for authentication; fill in this section in addition to
+; turning it on in [Authentication] above to use it. You must register your
+; VuFind instance as an application at http://developers.facebook.com to obtain
+; credentials.
+;[Facebook]
+;appId = "your app ID"
+;secret = "your app secret"
+
+; External Content is Optional.
+; To use multiple, separate with a comma.  Priority will be given by the order listed
+; Account id is separated with a colon, if no id is used then no colon is necessary
+;
+; IMPORTANT: Review content providers' terms of service before turning them on.
+;            Terms may change, and not all content sources are appropriate for all
+;            applications.  The existence of functionality in VuFind does not imply
+;            suitability for any particular situation.
+[Content]
+; You can define the cover size used by each template: false (to disable covers)
+; or size (small, medium, or large). A colon separated list may be used to try
+; multiple sizes in a particular order. All legal template values and default
+; values are reflected in the examples below. Uncomment the appropriate lines to
+; make changes.
+;coversize[checkedout] = small
+;coversize[collection-info] = medium
+;coversize[core] = medium
+;coversize[holds] = small
+;coversize[illrequests] = small
+;coversize[list-entry] = small
+;coversize[RandomRecommend] = "small:medium"
+;coversize[result-grid] = large
+;coversize[result-list] = small
+;coversize[similar-items] = large
+;coversize[storageretrievalrequests] = small
+
+; Alternatively, if you wish to disable covers completely, you may set the
+; coversize setting to false:
+coversize = false
+
+; You can select Syndetics, LibraryThing, Summon, Booksite, OpenLibrary,
+; Contentcafe, Buchhandel.de, Google, BrowZine, ObalkyKnih, Orb, Koha and/or
+; LocalFile. Service-specific notes:
+;   - BrowZine requires you to have BrowZine.ini configured appropriately.
+;   - Google Books caching behavior can be customized in the [Cache_GoogleCover]
+;       section.
+;   - Koha requires the koha_cover_url setting below. Additionally, for
+;       Koha to be a source of covers, its LocalCoverImages and
+;       OPACLocalCoverImages system preferences must be turned on and local cover
+;       images uploaded to the Koha system. Koha emits only two sizes of cover
+;       images, so small and medium are treated the same in VuFind.
+;   - LocalFile:PathToFile supports a combination of directory path information
+;       and tokens for filename and image type. If you have multiple directories
+;       in which you have stored coverimages, you can specify multiple paths to search
+;       by specifying multiple LocalFile:PathToFile in the coverage images list below.
+;       Allowed tokens:
+;          %anyimage%         - Match known image file extensions (gif, jpg, etc.)
+;          %isbn10%           - 10-digit ISBN
+;          %isbn13%           - 13-digit ISBN
+;          %issn%             - ISSN
+;          %oclc%             - OCLC Number
+;          %recordid%         - Bibliographic record ID
+;          %size%             - Size (small/medium/large)
+;          %source%           - Search backend of record (e.g. Summon, Solr, etc.)
+;          %upc%              - UPC Number
+;          %vufind-home%      - The VUFIND_HOME environment variable
+;          %vufind-local-dir% - The VUFIND_LOCAL_DIR environment variable
+;        Example: LocalFile:%vufind-local-dir%/path/to/file/%size%/issn/%issn%.%anyimage%
+;   - ObalkyKnih could be configured in obalkyknih.ini file. You should also
+;       add API URLs to img-src directive in contentsecuritypolicy.ini. As the
+;       conditions of use of ObalkyKnih require backlinks to provider, you need to
+;       also turn on ajaxcovers below - VuFind is able to show backlinks only
+;       through AJAX at this time.
+;   - Orb requires that you complete the [Orb] section. Cache settings can be
+;       adjusted in the [Cache_OrbCover] section.
+;   - Summon service takes a Serials Solutions client key, NOT Summon API key!
+;coverimages     = Syndetics:MySyndeticsId,Booksite,LibraryThing:MyLibraryThingId,Google,ObalkyKnih,OpenLibrary,Summon:MySerialsSolutionsClientKey,Contentcafe:MyContentCafeID,BrowZine,LocalFile:PathToFile,Koha,Orb
+
+; When using the Koha cover provider, you should fill in this setting:
+;koha_cover_url = "https://localhost/cgi-bin/koha/opac-image.pl"
+
+; This setting controls which services will have images cached on your local disk.
+; Set to true to cache all applicable services. Set to false to disable caching. Set
+; to a comma-separated list of services (e.g. "Syndetics,OpenLibrary") to cache only
+; a subset of selected services. Default = true. Note that due to terms of service,
+; some services will never have images cached even if caching is enabled.
+coverimagesCache = false
+
+; This setting controls which proxied image URLs will be cached to local disk (when
+; using the ?proxy= parameter of the standard /Cover/Show routes). The setting may
+; contain one or more regular expressions matching hostnames. The example
+; below will match any images from the mylibrary.edu domain; you can also use
+; "/.*/" to turn on caching for all proxied images.
+;coverproxyCache[] = "/.*\.?mylibrary\.edu/"
+; BrowZine DOI icons:
+;coverproxyCache[] = "/assets\.thirdiron\.com/"
+
+; This setting controls which hosts are allowed to provide cover images through
+; the built-in cover proxy. Images from hostnames that do not match the regular
+; expressions below will not be proxied. Be sure to define regular expressions
+; using an end of string ($) marker to prevent abuse.
+coverproxyAllowedHosts[] = "/assets\.thirdiron\.com$/"
+coverproxyAllowedHosts[] = "/\.summon\.serialssolutions\.com$/"
+
+; This setting controls the content types allowed through the cover proxy.
+; Note that proxying SVG files is not recommended because of their potential for
+; abuse in cross-site scripting attacks.
+coverproxyAllowedTypes[] = "image/gif"
+coverproxyAllowedTypes[] = "image/jpeg"
+coverproxyAllowedTypes[] = "image/png"
+
+; This setting controls how cover image URLs are loaded. They could be loaded as
+; part of main request, or asynchronously. Asynchronous loading is disabled by
+; default; to enable it, just uncomment the line below.
+;ajaxcovers = true
+
+; When ajaxcovers is set to true, this setting controls whether the AJAX Handler
+; GetRecordCover renders a fallback template (record/coverReplacement.phtml) in case
+; no cover image could be loaded.
+;useCoverFallbacksOnFail = false
+
+; These settings control the image to display when no book cover is available.
+; If makeDynamicCovers is not false and the GD library is installed, VuFind will draw
+; cover images on the fly. See [DynamicCovers] below for more settings. If set to
+; a non-Boolean value, for legacy reasons, the makeDynamicCovers setting will
+; be used as the backgroundMode setting of [DynamicCovers] if that setting is unset.
+;makeDynamicCovers = true
+
+; Otherwise, you can use noCoverAvailableImage to specify a
+; path relative to the base of your theme directory for a static image to display.
+noCoverAvailableImage = images/noCover2.gif
+
+; You can select from Syndetics, SyndeticsPlus, Booksite and/or the Guardian
+;   Note: If the API key is omitted, e.g. "Guardian:", only the review title, byline,
+;         Guardian logo and a link to the full Guardian page will be displayed
+;   Note: The Guardian API changed in 2014; if you signed up before that date, you
+;         may need to obtain a new API key for continued access.
+;reviews         = Syndetics:MySyndeticsId,SyndeticsPlus:MySyndeticsID,Booksite,Guardian:MyGuardianKeyId
+
+; You can select from Syndetics or SyndeticsPlus
+;excerpts        = Syndetics:MySyndeticsId,SyndeticsPlus:MySyndeticsId
+
+; This setting can be used to hide review/excerpt tabs on the record page when
+; no content is available from the providers. By default it is turned off. You
+; can turn it on for all relevant tabs by setting it to true, or you can turn
+; it on for a comma-separated list of values (e.g. "reviews" or "excerpts" or
+; "reviews,excerpts") for selective activation. Note that hiding empty tabs will
+; make your record pages slower, since it will require extra communication with
+; content providers.
+;hide_if_empty = reviews,excerpts
+
+; You can select from Syndetics or SyndeticsPlus to add summary information to
+; the description tab.
+;summaries = Syndetics:MySyndeticsId,SyndeticsPlus:MySyndeticsId
+
+; You can select from Syndetics, SyndeticsPlus or ObalkyKnih to load Tables of Contents
+;toc = Syndetics:MySyndeticsId,SyndeticsPlus:MySyndeticsId,ObalkyKnih
+
+; You can select from Syndetics or SyndeticsPlus
+;authorNotes = Syndetics:MySyndeticsId,SyndeticsPlus:MySyndeticsId
+
+; You can select from Wikipedia
+; See also the AuthorInfo recommendation module setting in searches.ini; this
+; includes notes on improving the accuracy of Wikipedia retrievals.
+; Note for Windows users: If using Wikipedia, you may need to increase your Apache
+; heap size settings.  For details, see: https://vufind.org/jira/browse/VUFIND-630
+;authors         = Wikipedia
+
+; You can select from Google, OpenLibrary, HathiTrust.  You should consult
+; https://developers.google.com/books/branding before using Google Book Search.
+;previews       = Google,OpenLibrary,HathiTrust
+
+; This setting controls whether or not cover images are linked to previews when
+; available. Legal settings are false (never link), * (always link; default), or
+; a comma-separated list of templates in which linking should occur (see coversize
+; above for a list of legal values).
+;linkPreviewsToCovers = *
+
+; Possible HathiRights options = pd,ic,op,orph,und,umall,ic-world,nobody,pdus,cc-by,cc-by-nd,
+; cc-by-nc-nd,cc-by-nc,cc-by-nc-sa,cc-by-sa,orphcand,cc-zero,und-world,icus
+; Default is "pd,ic-world" if unset here.
+; See www.hathitrust.org/rights_database#Attributes for full details
+;HathiRights    = pd,ic-world,cc-by,cc-by-nd,cc-by-nc-nd,cc-by-nc,cc-by-nc-sa,cc-by-sa,cc-zero,und-world
+
+; Possible GoogleBooks options full,partial,noview
+; options can be set for each / either of link or tab
+; Link makes a button appear in search results / record view
+; Tab makes a tab with an embedded preview appear on record view
+; Default is "GoogleOptions['link'] = full,partial" if nothing
+; is set here.
+; see https://developers.google.com/books/docs/dynamic-links#json-results-format
+;GoogleOptions['link']  = full,partial
+;GoogleOptions['tab']  = partial
+
+; OpenLibrary currently offers the same options/default as GoogleBooks (above):
+;OpenLibraryOptions  = full,partial
+
+; An API key is needed to interact with the Europeana API (see the EuropeanaResults
+; recommendation module in searches.ini for more information)
+;europeanaAPI = INSERTKEY
+
+; Geographic Display
+; These configuration settings have been superseded by the geofeatures.ini file.
+; See the [MapTab] section of the geofeatures.ini file for more information.
+
+; This section controls the behavior of the cover generator when makeDynamicCovers
+; above is non-false.
+;
+; Note that any of these settings may be filtered to be size-specific by subscripting
+; the key with a size. You can use a key of * for a default to use when a specific
+; size is not matched. This allows adjustment of certain elements for different
+; thumbnail sizes. See the "size" setting below for an example.
+[DynamicCovers]
+; This controls the background layer of the generated image; options:
+; - solid: display a solid color
+; - grid: display a symmetrical random pattern seeded by title/callnumber
+;backgroundMode = grid
+
+; This controls the text layer of the generated image; options:
+; - default: display a title at the top and an author at the bottom
+; - initial: display only the first letter of the title as a stylized initial
+;textMode = default
+
+; Font files specified here should exist in the css/font subdirectory of a theme.
+; Some options are available by default inside the root theme.
+;authorFont = "Roboto-Light.ttf"
+;titleFont = "RobotoCondensed-Bold.ttf"
+
+; In 'default' textMode, covers are generated using title and author name; VuFind
+; will try to display everything by doing the following: break the title into
+; lines, and if the title is too long (more than maxTitleLines lines), it will
+; display ellipses at the last line.
+;
+; All text will be drawn using the specified textAlign alignment value using the
+; relevant titleFontSize or authorFontSize setting, except that author names will
+; be reduced to the minAuthorFontSize option if needed, and if that doesn't make
+; it fit, text will be aligned left and truncated.
+;
+; When using 'initial' textMode, maxTitleLines and author-related settings are
+; ignored as they do not apply.
+;textAlign = center
+;titleFontSize = 9
+;authorFontSize = 8
+;minAuthorFontSize = 7
+;maxTitleLines = 4
+
+; All color options support the same basic set of values:
+; - The 16 named colors from HTML4
+; - Arbitrary HTML hex colors in the form #RRGGBB (e.g. #FFFF00 for yellow)
+; Some color options also support additional options.
+; - authorFillColor,titleFillColor: the main color used
+; - authorBorderColor,titleBorderColor: the color used to make a border; "none" is
+;   a legal option in addition to colors.
+; - baseColor: When using grid backgrounds, you may also choose a base color drawn
+;   beneath the grid. Default is white.
+; - accentColor: When using solid backgrounds, this is the background color; when
+;   using grid backgrounds, this is the color of the grid pattern beneath the text.
+;   You may set this to "random" to select a random color seeded with text from
+;   the cover and adjusted with the "lightness" and "saturation" settings below.
+;titleFillColor = black
+;titleBorderColor = none
+;authorFillColor = white
+;authorBorderColor = black
+;baseColor = white
+;accentColor = random
+; Note: lightness and saturation are only used when accentColor = random. Legal
+; ranges are 0-255 for each value.
+;lightness = 220
+;saturation = 80
+
+; These settings control the size of the image -- if size is a single number, a
+; square will be created; if it is a string containing an "x" (i.e. 160x190) it
+; defines a WxH rectangle. wrapWidth constrains the text size (and must be no
+; larger than the width of the canvas). topPadding and bottomPadding push the
+; text away from the edges of the canvas.
+;size[*] = 128
+;size[medium] = 200
+;size[large] = 500
+;topPadding = 19
+;bottomPadding = 3
+;wrapWidth = 110
+
+; This section is needed for Buchhandel.de cover loading. You need an authentication
+; token. It may also be necessary to customize your templates in order to comply with
+; terms of service; please look at http://info.buchhandel.de/handbuch_links for
+; details before turning this on.
+[Buchhandel]
+url = "https://api.vlb.de/api/v1/cover/"
+; token = "XXXXXX-XXXX-XXXXX-XXXXXXXXXXXX"
+
+[QRCode]
+; This setting controls the image to display when no qrcode is available.
+; The path is relative to the base of your theme directory.
+;noQRCodeAvailableImage = images/noQRCode.gif
+
+; Should we show QR codes in search results?
+;showInResults = true
+
+; Should we show QR codes on record pages?
+;showInCore = true
+
+; If you are using Syndetics Plus for *any* content, set plus = true
+; and set plus_id to your syndetics ID.  This loads the javascript file.
+; Syndetics vs. SyndeticsPlus: SyndeticsPlus has nice formatting, but loads slower
+; and requires javascript to be enabled in users' browsers.
+; set use_ssl to true if you serve your site over ssl and you
+; use SyndeticsPlus to avoid insecure content browser warnings
+; (or if you just prefer ssl)
+; NOTE: SyndeticsPlus is incompatible with the tabs/accordion [List] views in
+;       searches.ini. Do not turn it on if you are using these optional features.
+[Syndetics]
+; When the Syndetics cover image fallback is enabled, it will return generic covers based
+; on information Syndetics has related to the ISBN number or other number given. This
+; will prevent other fallbacks in VuFind from being tried, such as other cover image sources.
+; If the Syndetics cover image fallback is disabled, VuFind will query for the metadata first,
+; and only return an image if the Syndetics metadata returns a real cover image.
+use_syndetics_cover_image_fallback = false
+use_ssl = false
+plus = false
+;plus_id = "MySyndeticsId"
+; timeout value (in seconds) for API calls:
+timeout = 10
+
+; Orb does stand for Outil de Recherche Biblbiographique (tool for bibliographic
+; search). It's a french database of bibliographic information available by subscription.
+; Web site: https://www.base-orb.fr
+; API: http://doc.api.base-orb.fr/
+; It could be used in VuFind as cover image provider.
+[Orb]
+url = "api.base-orb.fr/v1"
+;user = api_test_user
+;key = api_access_key
+
+; Booksite CATS Enhanced Content - cover images, reviews, description, etc.
+[Booksite]
+url = "https://api.booksite.com"
+;key = "XXXXXXXXXXXXXXXXX"
+
+; Content Cafe is a subscription service from Baker & Taylor. If you are using this
+; service (see the [Content] section above for details), you MUST uncomment and set
+; the password (pw) setting. You may also change the API base URL (url) if needed.
+[Contentcafe]
+;url              = "http://contentcafe2.btol.com"
+;pw               = "xxxxxx"
+
+; Summon is optional; this section is used for your API credentials. apiId is the
+; short, human-readable identifier for your Summon account; apiKey is the longer,
+; non-human-readable secret key. See also the separate Summon.ini file.
+;[Summon]
+;apiId        = myAccessId
+;apiKey       = mySecretKey
+
+; This section must be filled in if you plan to use the optional WorldCat
+; search module. Otherwise, it may be ignored.
+;[WorldCat]
+;Your WorldCat search API key
+;apiKey          = "long-search-api-key-goes-here"
+;Your holdings symbol (usually a three-letter code) - used for excluding your
+; institution's holdings from the search results.
+;OCLCCode        = MYCODE
+
+; This section must be filled in to use Relais functionality. When
+; activated, this function will allow users to place ILL requests on unavailable
+; items through the record holdings tab.
+;
+; If you set apikey below, requests may be made from within VuFind through a
+; pop-up; if you omit apikey but set loginUrl and symbol, links will be provided
+; to Relais. Setting loginUrl and symbol is strongly recommended in all cases,
+; since links will be used as a fallback if the API fails.
+;[Relais]
+; Your library's holdings symbol (e.g. PVU for Villanova)
+;symbol="XYZ"
+; The pickup location to use for your institution (currently multiple pickup
+; locations are not supported here).
+;pickupLocation = "DEFAULT"
+; Barcode number (or other user ID) to use for lookups when none is provided
+;patronForLookup="99999999"
+; API key (may vary for testing vs. production)
+;apikey="your-relais-api-key-goes-here"
+; Timeout for HTTP requests (in seconds; set high, as Relais can be slow)
+;timeout = 500
+; Your institution's login URL for the remote Relais system (used to provide
+; a link when the API fails)
+;loginUrl = https://mysite.relais-host.com/user/login.html
+
+; TEST VALUES (uncomment for testing)
+;group="DEMO"
+;authenticateurl="https://demo.relais-host.com/portal-service/user/authentication"
+;availableurl="https://demo.relais-host.com/dws/item/available"
+;addurl="https://demo.relais-host.com/dws/item/add"
+
+; PRODUCTION VALUES (uncomment for live use)
+;group="EZB"
+;authenticateurl="https://mysite.relais-host.com/portal-service/user/authentication"
+;availableurl="https://mysite.relais-host.com/dws/item/available"
+;addurl="https://mysite.relais-host.com/dws/item/add"
+
+; DPLA key -- uncomment and fill in to use DPLATerms recommendations (see also
+; searches.ini).
+;[DPLA]
+;apiKey = http://dp.la/info/developers/codex/policies/#get-a-key
+
+; These settings affect dynamic DOI-based link inclusion; this can provide links
+; to full text or contextual information.
+[DOI]
+; This setting controls whether or not DOI-based links are enabled, and which
+; API is used to fetch the data. Currently supported options: BrowZine (requires
+; credentials to be configured in BrowZine.ini), Demo (which generates fake data
+; to simulate use of a real service, for testing), Unpaywall or false (to disable).
+; Disabled by default. You may also use a comma-separated list of resolvers if you
+; want to try multiple sources.
+;resolver = BrowZine
+
+; If you use multiple values in the resolver setting above, you can determine how the
+; software should behave when multiple resolvers return results for the same DOI.
+; You can choose "first" (only return results from the first matching resolver --
+; the default behavior) or "merge" (merge together all results and show them all).
+;multi_resolver_mode = first
+
+;unpaywall_api_url = "https://api.unpaywall.org/v2"
+; Unpaywall needs an email adress, see https://unpaywall.org/products/api
+;unpaywall_email = "your@email.org"
+
+; The following settings control where DOI-based links are displayed:
+show_in_results = true      ; include in search results
+show_in_record = false      ; include in core record metadata
+show_in_holdings = false    ; include in holdings tab of record view
+
+; Whether to load any third-party icons for the DOI services via VuFind's cover
+; loader proxy to avoid any privacy implications. Ensure that the necessary domains
+; are allowed in Content/coverproxyCache[] setting. Default is false.
+proxy_icons = true
+
+; Whether to open links in a new window. Default is false.
+;new_window = false
+
+; These settings affect OpenURL generation and presentation; OpenURLs are used to
+; help users find resources through your link resolver and to manage citations in
+; Zotero.
+[OpenURL]
+; If a resolver base URL is enabled, it will be used to link from records to your
+; OpenURL resolver. An OpenURL resolver is typically used to e.g. link to full text
+; from article metadata, but it may provide other services too. Extra parameters may
+; be added if necessary.
+;url             = "http://openurl.myuniversity.edu/sfx_local"
+
+; This string will be included as part of your OpenURL referer ID (the full string
+; will be "info:sid/[your rfr_id setting]:generator").  You may be able to configure
+; special behavior in your link resolver based on this ID -- for example, you may
+; wish to prevent the resolver from linking to VuFind when links came from VuFind
+; (to avoid putting a user in an infinite loop).
+rfr_id          = vufind.svn.sourceforge.net
+
+; By specifying your link resolver type, you can allow VuFind to optimize its
+; OpenURLs for a particular platform.  Current legal values: "sfx", "360link",
+; "JOP", "Redi", "Alma", "demo" or "generic" (default is "generic" if commented out;
+; "demo" generates fake values for use in testing the embed setting below).
+;resolver        = sfx
+
+; Some link resolver drivers can filter resource links based on specific criteria.
+; This setting indicates which filter reasons should NOT be used to exclude
+; resource links. This is currently ONLY supported by the Alma resolver driver.
+; (default is "Date Filter" if commented out, for backwards compatibility)
+; You may add new filters to the array by adding new lines in the format shown below
+; Currently known valid values include: Date Filter
+; ignoredFilterReasons[] = "Date Filter"
+; To deactivate this setting you can set
+; ignoredFilterReasons = false or one line ignoredFilterReasons = ""
+
+; If you want OpenURL links to open in a new window, set this setting to the
+; desired Javascript window.open parameters.  If you do not want a new window
+; to open, set this to false or comment it out.
+window_settings = "toolbar=no,location=no,directories=no,buttons=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=550,height=600"
+
+; If you want to display a graphical link to your link resolver, uncomment the
+; settings below.  graphic should be a URL; graphic_width and graphic_height
+; should be sizes in pixels.
+; Note: You will probably will need to add URL of image to img-src setting
+; in contentsecuritypolicy.ini file
+;graphic = "http://myuniversity.edu/images/findIt.gif"
+;graphic_width = 50
+;graphic_height = 20
+
+; If your link resolver can render an image in response to an OpenURL, you can
+; specify the base URL for image generation here:
+;dynamic_graphic = "http://my-link-resolver/image"
+
+; If dynamic_graphic is set above, the dynamic image can be used instead of the
+; standard text or static-image-based OpenURL link (true), it can be disabled
+; (false), or it can be displayed in addition to the regular link ("both").
+;image_based_linking_mode = both
+
+; The following settings control where OpenURL links are displayed:
+show_in_results = true      ; include in search results
+show_in_record = false      ; include in core record metadata
+show_in_holdings = false    ; include in holdings tab of record view
+
+; If set to true, this setting will attempt to embed results from the link
+; resolver directly in search results instead of opening a new window or page.
+; This will override the window_settings option if set! Embedding is currently
+; unsupported when the resolver setting above is set to "generic".
+embed = false
+
+; When embed is true and this is set to true results from the link resolver will
+; be loaded automatically (default is false, which requires a user click to trigger
+; the loading). Alternatively you can provide a comma-separated list of view areas
+; (cf. show_in_* settings) to autoload embedded OpenURLs only in certain views.
+; Notice: autoloading in results view might put some load on your linkresolver (each
+; results view could perform searches.ini->[General]->default_limit requests). You
+; might reduce load on the linkresolver by using the resolver_cache setting (see
+; below).
+embed_auto_load = false
+
+; When embed is true, you can set this to an absolute path on your system in order
+; to cache link resolver results to disk.  Be sure that the chosen directory has
+; appropriate permissions set!  Leave the setting commented out to skip caching.
+; Note that the contents of this cache will not be expired by VuFind; you should
+; set up an external process like a cron job to clear out the directory from time
+; to time.
+;resolver_cache = /usr/local/vufind/resolver_cache
+
+; This setting controls whether we should display an OpenURL link INSTEAD OF other
+; URLs associated with a record (true) or IN ADDITION TO other URLs (false).
+replace_other_urls = true
+
+; EZproxy is optional.  This section only needs to exist if you
+; are using EZProxy to provide off-site access to online materials.
+;[EZproxy]
+;host            = http://proxy.myuniversity.edu
+
+; By default, when the 'host' setting above is active, VuFind will prefix links in
+; records using EZproxy's "?qurl=" mechanism. If you need to set a host for ticket
+; authentication (below) but you want to disable the prefixing behavior, set this
+; to false.
+;prefixLinks = true
+
+; Use a web service to determine whether to prefix each link, ignoring prefixLinks
+; above unless the web service call fails.  Query the configured URL via HTTP GET
+; and a single query parameter, 'url', set to the link domain. The web service
+; should return a body with a single number, '1' to prefix and '0' if not.  The
+; web service should be hosted closely such that query time is minimal. See
+; https://github.com/lehigh-university-libraries/ezproxy-url-checker for an OSS
+; implementation of this protocol that extracts the answers from EZproxy config.
+;prefixLinksWebServiceUrl = http://localhost:8888/proxyUrl
+
+; Duration (seconds) to cache web service response data.  Default is 600.
+;prefixLinksWebServiceCacheLifetime = 600
+
+; Uncomment the following line and change the password to something secret to enable
+; EZproxy ticket authentication.
+;secret = "verysecretpassword"
+;
+; To enable ticket authentication in EZproxy, you will also need the following in
+; EZproxy's user.txt or ezproxy.usr for older versions (without the leading
+; semicolons and spaces):
+;
+; ::CGI=https://vufind-server/ExternalAuth/EzproxyLogin?url=^R
+; ::Ticket
+; TimeValid 10
+; SHA512 verysecretpassword
+;
+; Uncomment and modify the following line to use another hashing algorithm with the
+; EZproxy authentication if necessary. SHA512 is the default, but it requires at
+; least EZproxy version 6.1. Use "SHA1" for older EZproxy versions, and remember to
+; replace SHA512 with SHA1 also in EZproxy's configuration file.
+;secret_hash_method = "SHA512"
+
+; Uncomment the following line to disable relaying of user name to EZproxy on ticket
+; authentication:
+;anonymous_ticket = true
+; Uncomment the following line to disable logging of successful ticket
+; authentication requests in VuFind:
+;disable_ticket_auth_logging = true
+
+; These settings affect RefWorks record exports.  They rarely need to be changed.
+[RefWorks]
+vendor          = VuFind
+url             = https://www.refworks.com
+
+; These settings affect EndNote Web record exports.  They rarely need to be changed.
+[EndNoteWeb]
+vendor          = VuFind
+url             = https://www.myendnoteweb.com/EndNoteWeb.html
+
+; These settings affect your OAI server if you choose to use it.
+;
+; If identifier is set, its value will be used as part of the standard OAI
+; identifier prefix.  It should only ever be set to a domain name that you
+; control!  If it is not set, your ID values will not be prefixed.
+;
+; If admin_email is not set, the main email under [Site] will be used instead.
+;
+; page_size may be used to specify the number of records returned per request.
+; Default is 100. A higher number may improve overall harvesting performance, but
+; will also make a single response page larger and slower to produce.
+;
+; If set_field is set, the named Solr field will be used to generate sets on
+; your OAI-PMH server.  If it is not set, sets will not be supported.
+;
+; If set_query is set (as an array mapping set names to Solr queries -- see
+; examples below), the specified queries will be exposed as OAI sets.  If
+; you use both set_field and set_query, be careful about the names you choose
+; for your set queries. set_query names will trump set_field values when
+; there are collisions.
+;
+; default_query may be used to specify a filter for the default set, i.e. records
+; returned when a set is not specified.
+;
+; If vufind_api_format_fields is set, the listed fields (as defined in
+; SearchApiRecordFields.yaml) are returned when metadata prefix
+; "oai_vufind_json" is used.
+;
+; record_format_filters allows mapping from requested OAI metadataPrefix to query
+; filters. They can be used e.g. to limit results to records that can be returned in
+; the requested format.
+;
+; delete_lifetime controls how many days' worth of deleted records to include in
+; responses. Records deleted before the cut-off will not be included in responses.
+; Omit this setting to return all deleted records. This can be useful for long-lived
+; systems with many deleted records, to prevent full harvests from becoming unwieldy.
+;
+; use_cursor controls whether or not to use Solr's cursor functionality for deep
+; pagination of results. This defaults to true and is normally the preferred option,
+; but if you custom code to apply Solr features (such as result grouping/field
+; collapsing) that are incompatible with cursor-based pagination, you should turn
+; the feature off here.
+;
+;[OAI]
+;identifier       = myuniversity.edu
+;repository_name  = "MyUniversity Catalog"
+;admin_email      = oai@myuniversity.edu
+;page_size        = 1000
+;set_field        = "format"
+;set_query['eod_books'] = "institution:kfu AND publishDate:[1911 TO 1911]"
+;set_query['eod_ebooks'] = "format:eBook"
+;default_query = "institution:kfu"
+;vufind_api_format_fields = "id,authors,cleanIsbn,cleanIssn,formats,title"
+;record_format_filters[marc21] = "record_format:marc"
+;delete_lifetime = 365
+;use_cursor = true
+
+; Proxy Server is Optional.
+[Proxy]
+;host = your.proxy.server
+;port = 8000
+
+; Uncomment one of the following lines to set proxy type to SOCKS 5 or SOCKS 5 with
+; name resolution done by proxy. Setting either of these will make VuFind use the
+; curl adapter for HTTP requests.
+;type = socks5
+;type = socks5_hostname
+; This setting can be used to define a reqular expression pattern for addresses that
+; should be considered local and bypass proxy when making requests. Default is:
+;local_addresses = "@^(localhost|127(\.\d+){3}|\[::1\])@"
+; Following example bypasses also any address starting with '192.168.':
+;local_addresses = "@^(localhost|127(\.\d+){3}|\[::1\]|192\.168\.)@"
+
+; If VuFind is running behind a proxy that uses X-Real-IP/X-Forwarded-For headers,
+; you should configure this setting on so that VuFind reports correct user IP
+; addresses, and sets permissions appropriately. CONFIGURE THIS WITH CARE! It is
+; possible to spoof IP addresses, and configuring this to differentiate between
+; legitimate headers from your proxy and spoofed values is critical to protecting
+; your content.
+;
+; The setting should be an ordered, comma-separated list of headers, with optional
+; colon-separated modifiers specifying behavior.
+;
+; Header values can be any keys in PHP's $_SERVER superglobal array; these are
+; the most commonly used options:
+; - HTTP_X_FORWARDED_FOR
+; - HTTP_X_REAL_IP
+;
+; Supported behaviors (if unspecified, "single" is the default behavior):
+; - first (pick the first comma-separated value; e.g. "a" in "a, b, c")
+; - last (pick the last comma-separated value; e.g. "c" in "a, b, c")
+; - single (enforce single values; completely ignore multi-valued headers)
+;
+; See also forwarded_ip_filter below for a way to filter out known IP addresses
+; of internal network devices before applying first/last/single settings.
+;
+; When commented out or set to false, only the regular REMOTE_ADDR value will
+; be used for IP detection. REMOTE_ADDR will also be used as the default value
+; if none of the configured headers are populated.
+;
+; If you need to implement more nuanced functionality, you can extend or
+; override the VuFind\Net\UserIpReader class to implement your own logic.
+;
+; You can use a header-modifying browser plugin to determine how your proxy
+; will respond to spoofing attempts.
+;
+; See this wiki page for additional notes and comments:
+; https://vufind.org/wiki/administration:security#proxies_and_ip_authentication
+;
+; The example below, if uncommented, will use X-Real-IP if found, and the
+; rightmost value of X-Forwarded-For otherwise (resorting to REMOTE_ADDR only
+; if no relevant X- headers are found).
+;allow_forwarded_ips = "HTTP_X_REAL_IP:single,HTTP_X_FORWARDED_FOR:last"
+
+; This setting can be used in combination with allow_forwarded_ips to prevent
+; known IP addresses of internal proxies and network devices from being reported
+; as end user IP addresses. You can repeat the setting for each IP address that
+; you wish to exclude. The first/last/single processing parameters used by
+; allow_forwarded_ips will be applied AFTER removing addresses filtered here.
+;forwarded_ip_filter[] = 1.2.3.4
+
+; Default HTTP settings can be loaded here. These values will be passed to
+; the \Laminas\Http\Client's setOptions method.
+[Http]
+;sslcapath = "/etc/ssl/certs" ; e.g. for Debian systems
+;sslcafile = "/etc/pki/tls/cert.pem" ; e.g. for CentOS systems
+
+;timeout = 30 ; default timeout if not overridden by more specific code/settings
+
+@include = 'local_overrides/http.conf'
+
+; Example: Using a CURL Adapter instead of the defaultAdapter (Socket); note
+; that you may also need to install CURL and PHP/CURL packages on your server.
+;adapter = 'Laminas\Http\Client\Adapter\Curl'
+
+; Set curl options if required. See
+; https://www.php.net/manual/en/function.curl-setopt.php for available options and
+; https://github.com/curl/curl/blob/master/include/curl/curl.h for their numeric
+; values.
+;curloptions[52] = true
+
+; Spelling Suggestions
+;
+; Note: These settings affect the VuFind side of spelling suggestions; you
+; may also wish to adjust some Solr settings in solr/biblio/conf/schema.xml
+; and solr/biblio/conf/solrconfig.xml.
+[Spelling]
+enabled = true
+; Number of suggestions to display on screen. This list is filtered from
+;   the number set in solr/biblio/conf/solrconfig.xml so they can differ.
+limit   = 3
+; Show the full modified search phrase on screen
+;   rather then just the suggested word
+phrase = false
+; Offer expansions on terms as well as basic replacements
+expand  = true
+; Set the list of spellcheck dictionaries used in a Solr query. The
+; available dictionaries are defined in solrconfig.xml.
+; To improve performance by ignoring the more complicated 'shingle' (mini
+; phrases) based dictionary, disable 'default' to use only 'basicSpell'.
+; To use Solr's DirectSolrSpellChecker dictionary, enable 'direct' and
+; disable the others.
+; See https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html
+; for configuration of solrconfig.xml spellcheck parameters.
+dictionaries[] = default
+dictionaries[] = basicSpell
+;dictionaries[] = direct
+; This setting skips spell checking for purely numeric searches; spelling
+; suggestions on searches for ISBNs and OCLC numbers are not generally very
+; useful.
+skip_numeric = true
+
+; These settings control what events are logged and where the information is
+; stored.
+;
+; VuFind currently supports four logging levels: alert (severe fatal error),
+; error (fatal error), notice (non-fatal warning) and debug (informational).
+;
+; Each logging level can be further broken down into five levels of verbosity.
+; You can specify the desired level by adding a dash and a number after the
+; level in the configuration string -- for example, alert-2 or error-5.
+; The higher the number, the more detailed the logging messages.  If verbosity
+; is not specified, it defaults to 1 (least detailed).
+;
+; Several logging methods are available, and each may be configured to log any
+; combination of levels.
+;
+; You may enable multiple logging mechanisms if you want -- in fact, it is
+; recommended, since the failure of one logging mechanism (i.e. database down,
+; file system full) may then be reported to another.
+;
+; If database is uncommented, messages will be logged to the named MySQL table.
+; The table can be created with this SQL statement:
+; CREATE TABLE log_table ( id INT NOT NULL AUTO_INCREMENT,
+;     logtime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, ident CHAR(16) NOT NULL DEFAULT '',
+;     priority INT NOT NULL DEFAULT '0', message TEXT, PRIMARY KEY (id) );
+;
+; If file is uncommented, messages will be logged to the named file.  Be sure
+; that Apache has permission to write to the specified file!
+;
+; If email is uncommented, messages will be sent to the provided email address.
+; Be careful with this setting: a flood of errors can easily bog down your mail
+; server!
+[Logging]
+file             = "/usr/local/var/log/tuefind/vufind.log:alert,error,notice"
+;database       = log_table:alert,error,notice,debug
+; NOTE : Make sure the log file exists and that Apache has write permission.
+; NOTE : Windows users should avoid drive letters (eg. c:\vufind) because
+;        the colon will be used in the string parsing. "/vufind" will work
+;file           = /var/log/vufind.log:alert,error,notice,debug
+;email          = alerts@myuniversity.edu:alert-5,error-5
+
+; Get URL from https://YOURSLACK.slack.com/apps/manage/custom-integrations
+;slack = #channel_name:alert,error
+;slackurl = https://hooks.slack.com/services/your-private-details
+;slackname = "VuFind Log" ; username messages are posted under
+; You can also use the Slack settings to hook into Discord:
+; - Get your url from Server Settings > Webhooks
+; - Add /slack to the end of your url for Slack-compatible messages
+; https://discordapp.com/developers/docs/resources/webhook#execute-slackcompatible-webhook
+
+; You can use Office365 webhooks to send messages to a Microsoft Team channel.
+; In the "Connectors" setting on a channel, you can add "Incoming Webhook." This
+; will provide a URL that you can paste into the office365_url setting.
+; If you are concerned about rate limits, you might also wish to set up the
+; VuOwma message aggregator; see https://github.com/FalveyLibraryTechnology/VuOwma
+;office365_url = "https://outlook.office.com/webhook/xxx/IncomingWebhook/yyy"
+; This setting controls the error levels that will be logged to Office365; if
+; commented out, Office365 logging will be disabled
+;office365 = alert,error
+; This setting controls the title on the messages displayed in Office365:
+;office365_title = "VuFind Log"
+
+; Specify a reference id to inject in all log messages, for use later in querying
+; the logs.  See https://docs.laminas.dev/laminas-log/processors/#referenceid.
+; May be useful in tracking excessive use violations of licensed content.
+; - Default, false, includes no reference id.
+; - 'username' logs the currently logged-in username, if there is one.
+;reference_id = false
+
+; This section can be used to specify a "parent configuration" from which
+; the current configuration file will inherit.  You can chain multiple
+; configurations together if you wish.
+[Parent_Config]
+; Full path to parent configuration file:
+;path = /usr/local/vufind/application/config/config.ini
+; Path to parent configuration file (relative to the location of this file):
+;relative_path = ../parentconfig/config.ini
+
+; A comma-separated list of config sections from the parent which should be
+; completely overwritten by the equivalent sections in this configuration;
+; any sections not listed here will be merged on a section-by-section basis.
+;override_full_sections = "Languages,AlphaBrowse_Types"
+
+; This setting is for allowing arrays to be merged with the values of their parents
+; arrays. If override_full_sections is set for a section the arrays will always be
+; overridden.
+; For legacy reasons merging of arrays is disabled by default.
+;merge_array_settings = false
+
+; This section controls which language options are available to your users.
+; If you offer more than one option, a control will appear in the user
+; interface to allow user selection.  If you only activate one language,
+; the control will be hidden.
+;
+; The name of each setting below (i.e. en, de, fr) is a language code and
+; corresponds with one of the translation files found in the web/lang
+; directory.  The value of each setting is the on-screen name of the language,
+; and will itself be subject to translation through the language files!
+;
+; Enable "debug" to see the keys of the translation instead of a translation.
+; This can be helpful in development environments but should be deactivated
+; in production.
+;
+; The order of the settings is significant -- they will be displayed on screen
+; in the same order they are defined here.
+;
+; Be sure that this section includes the default language set in the [Site]
+; section above.
+[Languages]
+;debug       = "Debug"
+en               = "English"	; American spellings
+;en-gb            = "English"              ; British spellings
+de               = "German"
+es               = "Spanish"
+fr               = "French"
+it               = "Italian"
+;ja               = "Japanese"
+;nl               = "Dutch"
+;nl-be            = "Flemish Dutch"
+;pt               = "Portuguese"
+;pt-br            = "Brazilian Portugese"
+zh-cn            = "Simplified Chinese"
+;zh               = "Chinese"
+;tr               = "Turkish"
+;he               = "Hebrew"
+;ga               = "Irish"
+;cy               = "Welsh"
+;el               = "Greek"
+;ca               = "Catalan"
+;eu               = "Basque"
+;ru               = "Russian"
+;cs               = "Czech"
+;fi               = "Finnish"
+;sv               = "Swedish"
+;pl               = "Polish"
+;da               = "Danish"
+;sl               = "Slovene"
+;ar               = "Arabic"
+;bn               = "Bengali"
+;gl               = "Galician"
+;vi               = "Vietnamese"
+;hr               = "Croatian"
+;hi               = "Hindi"
+;hy          = "Armenian"
+;uk          = "Ukrainian"
+;se          = "Northern Sámi"
+;mn          = "Mongolian"
+;mi          = "Maaori"
+
+; This section contains special cases for languages such as right-to-left support
+[LanguageSettings]
+; Comma-separated list of languages to display in right-to-left mode
+rtl_langs = "ar,he"
+
+; This section controls the behavior of the Browse module.  The result_limit
+; setting controls the maximum number of results that may display in any given
+; result box on the Browse screen.  You can set to -1 for no limit; however,
+; setting a very high (or no) limit may result in "out of memory" errors if you
+; have a large index!
+[Browse]
+result_limit    = 100
+
+; These settings can be used to turn specific browse types on or off; the order
+; of the settings in the configuration below will also control the order of the
+; options displayed in the web interface:
+ixtheo-classification  = true	; allow browsing of ixtheo notation subdivisions
+relbib-classification = false   ; disable browsing of relbib notation
+tag              = false	; allow browsing of Tagsdewey            = true         ; allow browsing of Dewey Decimal call numbers
+topic            = true         ; allow browsing of subject headings
+author           = true         ; allow browsing of authors
+publisher        = true         ; allow browsing of publisher subdivisions
+tag              = false	; allow browsing of Tags
+lcc              = false	; allow browsing of LC call numbers
+genre            = false	; allow browsing of genre subdivisions
+region           = false	; allow browsing of region subdivisions
+era              = false	; allow browsing of era subdivisions
+
+; You can use this setting to change the default alphabet provided for browsing:
+;alphabet_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+; Uncomment to sort lists alphabetically (instead of by popularity); note that
+; this will not changed the values returned -- you will still get only the
+; <result_limit> most popular entries -- it only affects display order.
+;alphabetical_order = true
+
+; This section is used to configure bulk actions.
+[BulkActions]
+; Set the limit of items for each action. Set 0 to disable the action and hide the button.
+; Depending on your setup you may be able to increase the limits or have to decrease them
+; for the actions to work properly. limits["default"] is used for all actions that do not have
+; a limit themselves.
+limits["default"] = 100
+limits["email"] = 100
+limits["export"] = 100
+limits["print"] = 100
+limits["saveCart"] = 100
+limits["delete"] = 100
+
+; This section controls the availability of export methods.
+;
+; Each entry may be a comma-separated list of contexts in which the export
+; option will be presented. Valid options:
+;
+; bulk - Included in batch export contexts
+; record - Included in single-record export contexts
+;
+; If you simply set a field to true, only "record" mode will be enabled.
+; If you set a field to false, all export contexts will be disabled.
+;
+; Note that some options may be disabled for records that do not support them,
+; regardless of the setting chosen here.  You can edit the separate export.ini
+; file to add new export formats and change the behavior of existing ones.
+[Export]
+RefWorks         = false
+EndNote          = "record,bulk"
+EndNoteWeb       = false
+MARC             = "record"
+MARCXML          = false
+RDF              = false
+BibTeX           = "record,bulk"
+RIS              = "record,bulk"
+PPN_to_DA3       = "record"
+
+[BulkExport]
+; Export behavior to use when no bulkExportType setting is found in the matching
+; format section of export.ini; default is 'link' if not overridden below. See
+; export.ini for more details on available options.
+;defaultType = download
+enabled          = "1"
+options          = "RIS:BibTeX:MARC:MARCXML:EndNote:EndNoteWeb:RefWorks"
+
+;AddThis is optional. It uses the Add This tool available from www.addthis.com
+; and requires the username generated when an analytics account is registered.
+;[AddThis]
+;key = yourUsername
+
+; This section controls how item status information is presented in search results.
+[Item_Status]
+; Usually, there is only one location or call number for each item; however, when
+; multiple values are found, there are several possible behaviors:
+;     first = display the first value found, ignore the rest
+;     all   = show all of the values found, separated by commas
+;     msg   = show a message like "Multiple Call Numbers" or "Multiple Locations"
+;     group = show availability statuses for each location on a separate line,
+;             followed by callnumber information (valid for multiple_locations only)
+multiple_call_nos = first
+multiple_locations = msg
+
+; If your ILS driver supports services, VuFind will display a more detailed
+; availability message. This setting may be used to indicate that one particular
+; status is preferred over all others and should be displayed by itself when
+; found. This is useful because some drivers will always provide both "loan" and
+; "presentation" services, but most users will only care about "loan" (since in-
+; library use is implied by the ability to borrow an item). Set this to false to
+; always display all services.
+preferred_service = "loan"
+
+; Show the full location, call number, availability for each item.
+; You can customize the way each item's status is displayed by overriding the
+; ajax/status-full.phtml template.
+; When enabled, this causes the multiple_call_nos, multiple_locations and
+; preferred_service settings to be ignored.
+show_full_status = false
+
+; You can set this to the name of an alphabetic browse handler (see the
+; [AlphaBrowse_Types] section) in order to link call numbers displayed on the
+; holdings tab and in status messages to a specific browse list. Set to false
+; to disable call number linking.
+callnumber_handler = false
+
+; Load settings for result list. If you set "load_batch_wise" to true the statuses of multiple
+; records will be loaded batch wise. Otherwise each status will be loaded asynchronously.
+; Set "load_observable_only" to true if you want the statuses of the records only to be loaded
+; when they are visible. Otherwise all statuses of the records on the page will be loaded.
+load_batch_wise = true
+load_observable_only = true
+
+; If set to true, the item status display will include additional holdings text fields.
+; This option will only take effect when show_full_status is also set to true.
+include_holdings_text_fields = true
+
+; The set of additional holdings text fields shown in the item status display. If not
+; set explicitly, the default is to show all fields defined in holdings_text_fields[].
+;displayed_holdings_text_fields[] = 'holdings_notes'
+;displayed_holdings_text_fields[] = 'summary'
+
+
+; This section controls the behavior of the Record module.
+[Record]
+; Set this to true in order to enable "next" and "previous" links to navigate
+; through the current result set from within the record view.
+next_prev_navigation = true
+
+; Set this to true in order to enable "first" and "last" links to navigate
+; through the content result set from within the record view. Note, this
+; may cause slow behavior with some installations. The option will only work
+; when next_prev_navigation is also set to true.
+first_last_navigation = false
+
+; Set this to true if you want to display the permanent link option in the toolbar.
+permanent_link = true
+
+; Setting this to true will cause VuFind to skip the results page and
+; proceed directly to the record page when a search has only one hit.
+jump_to_single_search_result = false
+
+; You can enable this setting to show links to related MARC records using certain
+; 7XX fields. Just enter a comma-separated list of the MARC fields that you wish
+; to make use of.
+;marc_links = "760,762,765,767,770,772,773,774,775,776,777,780,785,787"
+; In the marc_links_link_types enter the fields you want the module to use to
+; construct the links. The module will run through the link types in order
+; until it finds one that matches. If you don't have id numbers in the fields,
+; you can also use title to construct a title based search. id represents a raw
+; bib id, dlc represents an LCCN.  Default setting:
+;marc_links_link_types = id,oclc,dlc,isbn,issn,title
+; Set use_visibility_indicator to false if you want to show links that are marked as
+; "Do not show" in the MARC record (indicator 1). Otherwise, these links will be
+; suppressed. (Default = true)
+;marc_links_use_visibility_indicator = false
+
+; When displaying publication information from 260/264, this separator will be
+; placed between repeating subfield values (default is to rely on existing ISBD
+; punctuation, but this can be used when ISBD punctuation is absent (e.g. ", ").
+;marcPublicationInfoSeparator = " "
+
+; If you have a custom index, you might want to change the field where the full
+; MARC record is supposed to be. The field will be checked and ignored, if it is
+; not a valid index field or does not exist in the record or index schema.
+; If you have multiple fields with MARC content, you may add all of them
+; by using a comma sepated list. The first field is the preferred one, if it does not
+; exist, the next ones are taken.
+; (Default = "fullrecord")
+preferredMarcFields = "fullrecord"
+
+; When displaying publication information from 260/264, this can be set to true
+; to make 264 information completely replace 260 information. Default is false,
+; which will display information from 260 AND 264 when both fields are populated.
+; Note that this only affects display, not indexing; both fields will always be
+; made searchable.
+;replaceMarc260 = false
+
+; Set the URI-pattern of the server which serves the raw Marc-data. (see
+; https://vufind.org/wiki/configuration:remote_marc_records for more information
+; on how to set up a remote service for raw Marc-data)
+;remote_marc_url = http://127.0.0.1/%s
+
+; You can use this setting to hide holdings information for particular named locations
+; as returned by the catalog.
+hide_holdings[] = "World Wide Web"
+
+; This array controls which Related modules are used to display sidebars on the
+; record view page.
+;
+; Available options:
+;    Channels - Display links to channels of content related to record
+;    Bookplate - Display a bookplate image or something similar
+;    MoreByAuthorSolr - Display books from the Solr index matching the current
+;                       record's primary author.
+;    Similar - Similarity based on Solr lookup
+;    WorldCat2Similar - Similarity based on WorldCat v2 lookup
+related[] = "Similar"
+;related[] = "MoreByAuthorSolr"
+
+; The following settings are for the related Bookplate module. They can be
+; enabled here by uncommenting below or from another config file of your choice.
+; To add them to another config file just pass the .ini file name and section
+; where they are found to the related module like so:
+;related[] = "Bookplate:Filename:Section"
+
+; How many items are displayed on the similar items carousel record tab.
+; Default is 40.
+;similar_carousel_items = 40
+
+; URLs for bookplates if enabled. The following tokens can be used:
+;   %%img%% - image name, partial image name or full URL.
+;   %%thumb%% - thumbnail image name, partial thumbnail image name or full URL.
+; If you index the entire path to bookplate images, you will only need to use
+; the token, e.g. bookplate_full = %%img%%, otherwise you can build URLs similar
+; to the ones below.
+;bookplate_full = https://your-institution.edu/bookplates/%%img%%-full.jpg
+;bookplate_thumb = https://your-institution.edu/bookplates/%%thumb%%-thumb.jpg
+
+; Data field with an array of image titles, parallel with bookplate_images_field.
+; Is required for alt text, even if bookplate_display_title is set to false.
+;bookplate_titles_field = "donor_str_mv"
+
+; Data field with an array of strings that represent the unique parts of image names,
+; or full URLs to images, parallel with bookplate_titles_field.
+;bookplate_images_field = "donor_code_str_mv"
+
+; Data field with an array of strings that represent the unique parts of thumbnail
+; image names or full URLs to thumbnail images, parallel with bookplate_titles_field.
+;bookplate_thumbnails_field = "donor_code_str_mv"
+
+; Display bookplate titles below bookplate images
+;bookplate_display_title = true
+
+; This setting controls which citations are available; set to true for all supported
+; options (default); set to false to disable citations; set to a comma-separated list
+; to activate only selected formats (available options: APA, Chicago, MLA). The
+; comma-separated list option may also be used to customize citation display order.
+;citation_formats = APA,Chicago,MLA
+
+; Only display x number of subjects in the bib display on the full record by default.
+; Additional subjects are hidden by default and expandable via a "more..." button.
+; Enable by setting to a number, e.g. 3, to display 3 subjects and hide the rest.
+;subjectLimit = false
+; Only display x number of items in the holdings tab on the full record by default.
+; Additional items are hidden by default and expandable via a "more..." button.
+; Enable by setting to a number, e.g. 3, to display 3 items and hide the rest.
+;holdingsItemLimit = false
+
+; Whether to always display the index fields in staff view (i.e. also for MARC
+; records). Default is false.
+;alwaysDisplayIndexRecordInStaffView = false
+
+; Embed schema.org RDFa metadata into record displays?
+includeSchemaOrgMetadata = true
+
+; This setting controls the display order of subject headings from MARC records.
+; If set to "record" (the default) it will retain the order of headings from the MARC record.
+; If set to "numerical", it will sort numerically by MARC tag.
+;marcSubjectHeadingsSort = "numerical"
+
+; The following two sections control the Alphabetic Browse module.
+[AlphaBrowse]
+; This setting controls how many headings are displayed on each page of results:
+page_size = 20
+; How many headings to show before the match (or the spot where the match
+; would have been found). Default is 0 for backwards compatibility.
+rows_before = 0
+; highlight the match row (or spot where match would have been)? default false
+highlighting = true
+; AlphaBrowse results are not subject to dynamic filtering. If you have default
+; filters defined in searches.ini, you most likely will want to disable them when
+; users navigate from browse results to search results, to ensure that the result
+; count is consistent between the browse listing and the search listing. However,
+; in the rare situation that you have configured default filters that BROADEN
+; rather than NARROW search results, you will likely want to change this setting
+; to false to avoid inconsistencies.
+bypass_default_filters = true
+; SEE ALSO: the General/includeAlphaBrowse setting in searchbox.ini, for including
+; alphabrowse options in the main search drop-down options.
+
+; This section controls the order and content of the browse type menu in the
+; Alphabetic Browse module.  The key is the browse index to use, the value is the
+; string to display to the user (subject to translation).
+[AlphaBrowse_Types]
+topic = "By Topic"
+author = "By Author"
+title = "By Title"
+lcc = "By LCC Call Number"
+;dewey = "By Call Number"
+
+; This section controls the return of extra columns for the different browses.
+; The key is the browse index, the value is a colon-separated string of extra
+; Solr fields to return for display to the user.
+; Values should be in translation file as browse_value.
+[AlphaBrowse_Extras]
+title = "author:format:publishDate"
+lcc = title
+dewey = title
+
+; This section controls a potential additional filter for different frontends
+[AlphaBrowse_Filter]
+filter = "is_augustine"
+
+; This section allows you to configure the values used for Cryptography; the
+; HMACkey can be set to any value you like and should never be shared.  It is used
+; to prevent users from tampering with certain URLs (for example, "place hold" form
+; submissions)
+[Security]
+@include = 'local_overrides/hmac.conf'
+
+; This section sets global defaults for caches; file caching is used by default.
+; A custom directory for caching can be defined by the environment variable
+; VUFIND_CACHE_DIR (see httpd-vufind.conf). The default location is inside the
+; local settings directory.
+[Cache]
+; Uncomment the following line to disable all caching
+;disabled = true
+; Set time to live value for caches (in seconds), 0 means maximum possible.
+;ttl = 0
+; Override umask for cache directories and files.
+;umask = 022
+; Permissions for framework-created cache directories and files, subject to umask
+; Default dir_permission seems to be 0700.
+;dir_permission = 0700
+; Default file_permission seems to be 0600.
+;file_permission = 0600
+
+; The following Cache_ sections are empty. You can use them to override the
+; default settings from the [Cache] section in the given context if necessary.
+[Cache_GoogleCover]
+[Cache_OrbCover]
+
+[Cache_Zeder]
+; Set time to live value for caches (in seconds), 0 means maximum possible.
+ttl = 3600
+
+; This section controls the "Collections" module -- the special view for records
+; that represent collections, and the mechanism for browsing these records.
+[Collections]
+; Control whether or not the collections module is enabled in search results.
+; If set to true any search results which are collection level items will
+; link to the respective collections page rather than the record page
+; (default = false).
+;collections = true
+; Control default tab of Collection view (default = CollectionList); see also
+; CollectionTabs.ini.
+;defaultTab = CollectionList
+; This controls where data is retrieved from to build the Collections/Home page.
+; It can be set to Index (use the Solr index) or Alphabetic (use the AlphaBrowse
+; index). Index is subject to "out of memory" errors if you have many (150000+)
+; collections; Alphabetic has no memory restrictions but requires generation of
+; a browse index using the index-alphabetic-browse tool.  (default = Index)
+;browseType = Index
+; This string is the delimiter used between title and ID in the hierarchy_browse
+; field of the Solr index.  Default is "{{{_ID_}}}" but any string may be used;
+; be sure the value is consistent between this configuration and your indexing
+; routines.
+;browseDelimiter = "{{{_ID_}}}"
+; This controls the page size within the Collections/Home page (default = 20).
+;browseLimit = 20
+; List of record routes that are converted to collection routes (used to map
+; route names when a record identifies itself as a collection and the collections
+; setting above is true).
+route[record] = collection
+route[search2record] = search2collection
+
+; This section addresses hierarchical records in the Solr index
+[Hierarchy]
+; Name of hierarchy driver to use if no value is specified in the hierarchytype
+; field of the Solr index.
+driver = Default
+; Should we display hierarchy trees? (default = false)
+;showTree = true
+; "Search within trees" can be disabled here if set to "false" (default = true)
+search = true
+; You can limit the number of search results highlighted when searching the tree;
+; a limit is recommended if you have large trees, as otherwise large numbers of
+; results can cause performance problems.  If treeSearchLimit is -1 or not set,
+; results will be unlimited.
+treeSearchLimit = 100
+; Whether hierarchy fields are used for linking between container records and their
+; children (default = false). This is an alternative to the full collections support
+; (see the [Collections] section), so only one of them should be enabled
+; at a time e.g. unless custom record drivers are used. When using this setting,
+; you may also wish to enable the ComponentParts tab in RecordTabs.ini.
+;simpleContainerLinks = true
+; If true, throw an exception if hierarchy parent and sequence data is out of sync.
+validateHierarchySequences = true
+
+; This section will be used to configure the feedback module.
+; Set "tab_enabled" to true in order to enable the feedback module.
+; Forms are configured in FeedbackForms.yaml
+[Feedback]
+;tab_enabled       = true
+
+; Default values for form recipient and email subject, if not overridden for a
+; specific form in FeedbackForms.yaml
+;recipient_email   = "feedback@myuniversity.edu"
+;recipient_name    = "Your Library"
+;email_subject     = "VuFind Feedback"
+
+;recipient_email   = "feedback@myuniversity.edu"                    ;see Site email (local overrides)
+recipient_name    = "Index Biblicus"
+email_subject     = "Index Biblicus Feedback"
+; This is the information for where feedback emails are sent from.
+sender_email      = "no-reply@ub.uni-tuebingen.de"
+sender_name       = "Index Biblicus Feedback"
+
+@include = local_overrides/bibstudies_site.conf
+
+; Note: for additional details about stats (including additional notes on Google
+; Analytics and Matomo/Piwik), look at the wiki page:
+;     https://vufind.org/wiki/configuration:usage_stats
+
+; Uncomment this section and provide your Container ID key to enable Google Tag Manager.
+; For information on installing GTM and identifying your GTM Container ID, see:
+; https://support.google.com/tagmanager/answer/6103696
+;[GoogleTagManager]
+;gtmContainerId = "GTM-1234567"
+
+; Uncomment this section and provide your API key to enable Google Analytics.
+;[GoogleAnalytics]
+;apiKey = "mykey"
+; Options to pass to the ga() function's create call; if omitted, defaults to
+; 'auto'. The example below can be uncommented to work around a common problem
+; with browsers complaining about problems with the samesite attribute. Note
+; that the value of this setting must be valid Javascript code, so be careful
+; about quoting and escaping.
+; Note: only supported when universal is set to true.
+;create_options_js = "{cookie_flags: 'max-age=7200;secure;samesite=none'}"
+
+; Matomo analytics version 4 and later (for version 3 and earlier, use Piwik section
+; below):
+; Uncomment this section and provide your Matomo server address and site id to enable
+; Matomo analytics.
+[Matomo]
+url = "https://vitruv.uni-tuebingen.de/piwik/"
+site_ids = ptah.ub.uni-tuebingen.de:30, bible.ixtheo.de:29, bibel.ixtheo.de:29
+; Uncomment and modify the following settings to track additional information about
+; searches and displayed records with Matomo's custom dimensions. Each entry maps an
+; information field to a custom dimension. The list of settings below contains all
+; the fields available. Note that you may need to increase the custom dimensions
+; limit in Matomo to track all the information needed (see the custom dimensions
+; configuration page in Matomo for more information).
+;custom_dimensions[Facets] = 1
+;custom_dimensions[FacetTypes] = 2
+;custom_dimensions[SearchType] = 3
+;custom_dimensions[SearchBackend] = 4
+;custom_dimensions[Sort] = 5
+;custom_dimensions[Page] = 6
+;custom_dimensions[Limit] = 7
+;custom_dimensions[View] = 8
+;custom_dimensions[RecordFormat] = 9
+;custom_dimensions[RecordData] = 10
+;custom_dimensions[RecordInstitution] = 11
+;custom_dimensions[Context] = 12
+; Uncomment the following setting to track additional information about searches
+; and displayed records with Matomo's custom variables. Matomo recommends using
+; custom dimensions instead, but you can choose to use either or both.
+; Note: To use custom variables you must reconfigure Matomo by making sure that the
+; Custom Variables plugin is enabled, switching to Matomo's root directory and
+; running this command to raise the default limit of custom variables from 5 to 10:
+; ./console customvariables:set-max-custom-variables 10
+custom_variables = true
+; By default, searches are tracked using the format "Backend|Search Terms."
+; If you need to differentiate searches coming from multiple VuFind instances using
+; a shared site_id, you can set the searchPrefix to add an additional prefix to
+; the string, for example "SiteA|Backend|Search Terms." Most users will want to
+; leave this disabled.
+;searchPrefix = "SiteA|"
+; Uncomment the following setting to disable cookies for privacy reasons.
+; see https://matomo.org/faq/general/faq_157/ for more information.
+;disableCookies = true
+
+; Piwik and Matomo 3.x (for Matomo version 4 and later, use Matomo section above):
+; The Piwik product has been renamed to Matomo, but for backward compatibility,
+; the terminology has not yet been changed in VuFind. Uncomment this section and
+; provide your Matomo or Piwik server address and site id to enable Matomo/Piwik
+; analytics. Note: VuFind's Matomo/Piwik integration uses several custom variables;
+; to take advantage of them, you must reconfigure Matomo/Piwik by switching
+; to its root directory and running this command to raise a default limit:
+; ./console customvariables:set-max-custom-variables 10
+[Piwik]
+;url = "http://server.address/piwik/"
+;site_id = 1
+; Uncomment the following setting to track additional information about searches
+; and displayed records with Matomo/Piwik's custom variables
+;custom_variables = true
+; By default, searches are tracked using the format "Backend|Search Terms."
+; If you need to differentiate searches coming from multiple VuFind instances using
+; a shared site_id, you can set the searchPrefix to add an additional prefix to
+; the string, for example "SiteA|Backend|Search Terms." Most users will want to
+; leave this disabled.
+;searchPrefix = "SiteA|"
+; Uncomment the following setting to disable cookies for privacy reasons.
+; see https://matomo.org/faq/general/faq_157/ for more information.
+;disableCookies = true
+
+; Uncomment portions of this section to activate tabs in the search box for switching
+; between search modules. Keys are search backend names, values are labels for use in
+; the user interface (subject to translation). If you need multiple tabs for a single
+; backend, append a colon and a suffix to each backend name (e.g. Solr:main) and add
+; the filters in the [SearchTabsFilters] section.
+[SearchTabs]
+Solr = 'IxAug'
+Search2:fulltext = "Fulltexts"
+SolrAuth = "Persons / Corporations"
+;Solr = Catalog
+;Summon = Summon
+;WorldCat2 = WorldCat
+;Solr:filtered = "Catalog (Main Building Books)"
+;EDS = "EBSCO Discovery Service"
+;EIT = "EBSCO Integration Toolkit"
+;Primo = "Primo Central"
+
+; Add any hidden filters in this section for search tab specific filtering
+[SearchTabsFilters]
+Search2:fulltext = 'has_fulltext:1'
+;Solr:filtered[] = 'building:"main library"'
+;Solr:filtered[] = "format:book"
+
+; You can bind a permission to a search tab in this section.
+; This controls to whom the tab should be displayed.
+; Use the format tabName = permission. The permission should be configured
+; in permissions.ini (who should see the tab)
+; and permissionBehavior.ini (what should be displayed instead of the tab).
+; Note that this ONLY controls whether or not the tab is displayed; if you wish to
+; restrict actual searching, you will also need to make sure that the relevant
+; controller(s) are blocking access using the same named permission.
+[SearchTabsPermissions]
+;EIT = access.EITModule
+;Primo = access.PrimoModule
+
+; This section contains additional settings impacting Search Tabs behavior.
+[SearchTabsSettings]
+; If set to true, result counts will be displayed next to inactive tabs (by performing
+; searches in the background using AJAX). Default = false.
+;show_result_counts = false
+
+; Uncomment portions of this section to label searches from particular sources in the
+; search history display.  Keys are search backend names, values are labels for use in
+; the user interface (subject to translation).
+[SearchHistoryLabels]
+;Solr = Catalog
+;Summon = Summon
+;WorldCat2 = WorldCat
+;SolrWeb = "Library Website"
+;EDS = "EBSCO Discovery Service"
+
+; Activate Captcha validation on select forms
+; VuFind can use Captcha validation to prevent bots from using certain actions of
+; your instance.
+[Captcha]
+; Valid type values:
+; - dumb (ask the user to reverse a random string; only recommended for testing)
+; - figlet (generate a text-based message for the user to interpret; DEPRECATED --
+;   will be removed in release 11.0)
+; - image (generate a local image for the user to interpret)
+; - interval (allow an action after a specified time has elapsed from session start
+;   or previous action)
+; - recaptcha (use Google's ReCaptcha service)
+; If multiple values are given, the user will be able to pick his favorite.
+; See below for additional type-specific settings.
+types[] = image
+
+; The "forms" setting controls the contexts in which CAPTCHA will be presented. It
+; can be either a comma-separated list of forms, or "*" to display CAPTCHA on all
+; supported forms. Valid forms values:
+;       changeEmail, changePassword, email, feedback, newAccount, passwordRecovery,
+;       sms, userComments
+; Note: when "feedback" is active, Captcha can be conditionally disabled on a
+;       form-by-form basis with the useCaptcha setting in FeedbackForms.yaml.
+forms = feedback
+
+; Figlet options, see:
+;      https://docs.laminas.dev/laminas-captcha/adapters/#laminascaptchafiglet
+;figlet_length = 8
+
+; Image options, see:
+;      https://docs.laminas.dev/laminas-captcha/adapters/#laminascaptchaimage
+;image_length = 8
+;image_width = 200
+image_height = 75
+;image_fontSize = 24
+image_dotNoiseLevel = 50
+image_lineNoiseLevel = 3
+
+; Interval options:
+; Minimum interval between actions (seconds, default is 60):
+;action_interval = 60
+; Minimum time between session start and first action (seconds, default is
+; action_interval):
+;time_from_session_start = 0
+
+; See http://www.google.com/recaptcha for more information on reCAPTCHA and to
+; create keys for your domain. Make sure that SSL settings are correct in the
+; [Http] section, or your Captcha may not work.
+;recaptcha_siteKey  = "get your reCaptcha key at"
+;recaptcha_secretKey = "https://www.google.com/recaptcha/admin/create"
+; Use recaptcha_secretKey_file to load the secret from another file instead of including it directly in this configuration.
+;recaptcha_secretKey_file = /path/to/secret
+; Valid theme values: dark, light
+;recaptcha_theme      = light
+
+; This section can be used to display default text inside the search boxes, useful
+; for instructions. Format:
+;
+; backend = Placeholder text
+;
+; You can use a "default" setting if you want a standard string displayed across
+; all backends not otherwise specified. You can qualify backend names with a
+; colon-delimited suffix if you wish to use special placeholders in combination
+; with filtered search tabs (see [SearchTabsFilters] above).
+[SearchPlaceholder]
+default = "Search for keywords, title or author"
+Search2:fulltext = "Search the Full Texts"
+SolrAuth = "Search for person, corporate, conference"
+;Solr = "Search the catalog"
+;Solr:filtered = "Search the filtered catalog"
+;SolrReserves = reserves_search_placeholder
+;Summon = "Search Summon"
+
+; This section controls VuFind's social features.
+[Social]
+; Comments may be "enabled" or "disabled" (default = "enabled")
+comments = disabled
+; Whether rating is enabled (true or false, default is false)
+rating = false
+; Whether the user is allowed to remove a rating (true or false, default is true)
+remove_rating = true
+; Favorite lists may be "enabled", "disabled", "public_only" or "private_only"
+; (default = "enabled")
+; The public_only/private_only settings restrict the type of list users may
+; create. If you change this to a more restrictive option, it is your responsibility
+; to update the user_list database table to update the status of existing lists.
+lists = enabled
+; The following two settings are equivalent to default_limit / limit_options in
+; searches.ini, but used to control the page sizes of lists of favorites:
+lists_default_limit   = 20
+;lists_limit_options   = 10,20,40,60,80,100
+; If multi page selection is activated one can select elements on one page in the favorite list
+; and the elements will stay selected when switching to another page.
+multi_page_favorites_selection = true
+; Choose which type of select_all checkbox should be shown in the favorite list.
+; on_page - selects all elements on the current page
+; global - selects all elements of the current list (only works if multi page selection is enabled)
+; both - shows on_page and global (only works if multi page selection is enabled)
+; none - disable select_all checkboxes
+checkbox_select_all_favorites_type = both
+; This section controls what happens when a record title in a favorites list
+; is clicked. VuFind can either embed the full result directly in the list using
+; AJAX or can display it at its own separate URL as a full HTML page.
+; See the [List] section of searches.ini for all available options.
+lists_view=full
+; Tags may be "enabled" or "disabled" (default = "enabled")
+; When disabling tags, don't forget to also turn off tag search in searches.ini.
+tags = disabled
+; User list tags may be "enabled" or "disabled" (default = "disabled")
+listTags = disabled
+; This controls the maximum length of a single tag; it should correspond with the
+; field size in the tags database table.
+max_tag_length = 64
+; This controls whether tags are case-sensitive (true) or always forced to be
+; represented as lowercase strings (false -- the default).
+case_sensitive_tags = true
+; If this setting is set to false, users will not be presented with a search
+; drop-down or advanced search link when searching/viewing tags. This is recommended
+; when using a multi-backend system (e.g. Solr + Summon + WorldCat2). If set to
+; true, the standard Solr search options and advanced search link will be shown
+; in the tag screens; this is recommended when using a Solr-only configuration.
+show_solr_options_in_tag_search = false
+
+; This section defines the sort options available in the favorites list.
+; Values on the left of the equal sign are either the reserved term "last_saved"
+; for the date a resource was last saved to a list or the "title", "author" or
+; "year" column of the resource table;
+[List_Sorting]
+title = sort_title
+author = sort_author
+year DESC = sort_year
+year = sort_year_asc
+last_saved DESC = sort_saved
+last_saved = sort_saved_asc
+
+; These settings control VuFind's APIs.
+; See https://vufind.org/wiki/development:apis for more information.
+[API]
+; Description of the API displayed in the OpenAPI specification and Swagger UI
+; (may contain Markdown, see https://spec.commonmark.org/):
+description = "The REST API provides access to search functions and records contained in the search index."
+; URL pointing to a Terms of Service page (optional, default is none):
+;termsOfServiceUrl = "https://something"
+
+[Sorting]
+; By default, VuFind sorts text in a locale-agnostic way; if this setting is
+; turned on, the current user-selected locale will impact sort order.
+;use_locale_sorting = true
+
+;Needed because otherwise SolrMarc cannot find the database
+;Quotation marks on the right hand side must be left out
+[Extra_Config]
+local_overrides = local_overrides/database_solrmarc.conf

--- a/local/tuefind/instances/augustine/config/vufind/contentsecuritypolicy.ini
+++ b/local/tuefind/instances/augustine/config/vufind/contentsecuritypolicy.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/contentsecuritypolicy.ini

--- a/local/tuefind/instances/augustine/config/vufind/export.ini
+++ b/local/tuefind/instances/augustine/config/vufind/export.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/export.ini

--- a/local/tuefind/instances/augustine/config/vufind/facets.ini
+++ b/local/tuefind/instances/augustine/config/vufind/facets.ini
@@ -1,0 +1,426 @@
+; The order of display is as shown below
+; The name of the index field is on the left
+; The display name of the field is on the right
+[Results]
+; institution          = Institution
+; building             = Library
+format                = Format
+
+; Use callnumber-first for LC call numbers, dewey-hundreds for Dewey Decimal:
+;callnumber-first      = "Call Number"
+;dewey-hundreds     = "Call Number"
+is_open_access        = Open Access
+mediatype             = Mediatype
+;hierarchy_top_title   = Collections
+author_facet          = Author
+language              = Language
+genre_facet           = Genre
+era_facet             = Era
+geographic_facet      = Region
+publishDate           = "adv_search_year"  ; share year string w/advanced search page
+
+dewey-hundreds        = "Call Number"
+topic_facet           = "Topic"
+;physical              = "Physical Format"
+;key_word_chains       = "Keyword Chains"
+publisher_facet       = Publisher
+ixtheo_notation_facet = "IxTheo-Classification"
+
+;collapse_expand       = "Collapse Expand debug"
+
+; Facets that will appear at the top of search results when the TopFacets
+; recommendations module is used.  See the [TopRecommendations] section of
+; searches.ini for more details.
+[ResultsTop]
+topic_facet        = "Suggested Topics"
+
+; This section controls where facet labels are retrieved from when facets are not
+; explicitly configured.
+[FacetLabels]
+; This setting lists configuration sections containing facet field => label
+; mappings. Later values will override earlier values. These mappings will be used
+; only when a label is not explicitly configured (i.e. through SideFacets settings).
+; If you customize your facet display, be sure to add any new facet configuration
+; sections to this list to ensure proper display in search history, etc.
+labelSections[] = Advanced
+labelSections[] = HomePage
+labelSections[] = ResultsTop
+labelSections[] = Results
+labelSections[] = ExtraFacetLabels
+
+; This setting lists configuration settings defining checkbox facets. If you use
+; a custom section to configure additional facets, be sure to add it to this list
+; so labels display correctly in history, the advanced search editor, etc. If you
+; are using the reverse label => filter format rather than filter => label, you
+; should prefix the section name with a ~ character to ensure proper loading.
+checkboxSections[] = CheckboxFacets
+
+; This section is used to specify labels for facets that may be applied by parts
+; of VuFind other than the facet lists defined in this file (for example, the
+; hierarchical browse of the BrowseController, or the Geographic Search).
+[ExtraFacetLabels]
+long_lat = "Geographic Search"
+
+; This section is used to identify facets for special treatment by the SideFacets
+; recommendations module.
+[SpecialFacets]
+; Any fields listed below will be treated as year-based date ranges rather than plain
+; facets:
+dateRange[] = publishDate
+; Any fields listed below will be treated as year/month/day-based date ranges rather
+; than plain facets:
+;fullDateRange[] = example_field_date
+; Any fields listed below will be treated as numeric ranges rather than plain facets:
+;numericRange[] = example_field_str
+; Any fields listed below will be treated as free-form ranges rather than plain
+; facets:
+;genericRange[] = example_field_str
+; Any fields listed below will be treated as hierarchical facets
+; (see https://wiki.apache.org/solr/HierarchicalFaceting but note that we always
+; use a trailing slash to avoid ambiguities)
+;hierarchical[] = building
+;hierarchical[] = format
+
+; General sort options for hierarchical facets (Home page, Advanced Search and
+; SideFacets).
+;
+; You can set a general default setting with * and set field-specific overrides
+; using field names (see example below).
+;
+; Available options:
+; top   = Sort the top level list alphabetically, others by result count (useful e.g.
+;         for a large number of building facets where top level is organization and
+;         second level the library branch)
+; all   = Sort all levels alphabetically
+; count = Sort all levels by count
+;
+; Note: this section may be overridden for HomePage and Advanced search facets (see
+; hierarchicalFacetSortOptions in HomePage_Settings and Advanced_Settings below).
+;
+; By default, if no settings are configured in this file, the default sort will be
+; 'count' for SideFacets values, 'all' for HomePage values, and 'top' for Advanced
+; values.
+;hierarchicalFacetSortOptions[*] = all
+;hierarchicalFacetSortOptions[building] = top
+
+; How hierarchical facet values are displayed in the records:
+; single = Display only the deepest level (default)
+; full   = Display full hierarchy for each entry
+;hierarchicalFacetDisplayStyles[format] = full
+; Separator used when displaying hierarchical facet levels (default is "/")
+;hierarchicalFacetSeparators[format] = " > "
+
+; This section is reserved for special boolean facets.  These are displayed
+; as checkboxes.  If the box is checked, the filter on the left side of the
+; equal sign is applied.  If the box is not checked, the filter is not applied.
+; The value on the right side of the equal sign is the text to display to the
+; user.  It will be run through the translation code, so be sure to update the
+; language files appropriately.
+;
+; Leave the section empty if you do not need checkbox facets.
+[CheckboxFacets]
+; Contrived hypothetical example:
+;edition:1st* = "First Edition"
+; Inverted custom filter example; see [CustomFilters] below for related settings:
+;vufind:include_books = "Include Books"
+is_augustine:true = "Augustine Titles Only"     ; Contrived hypothetical example
+
+; Available sort options when listing all facets from Sidefacets.
+;
+; Each configuration option targets a search class and a facet field.
+; All facet fields for a search class can be targeted using the wildcard '*'.
+; Sort options are given as a comma-separated list of "<sort-field>=<label>" entries,
+; where <sort-field> is either 'count' or 'index' and <label> the translation
+; key for the option.
+[AvailableFacetSortOptions]
+; By default all Solr facets can be sorted by count and alphabetically.
+
+; Example: sort Solr author_facet by count only.
+; Solr[author_facet] = "count=sort_count"
+
+; Example: sort Solr author_facet only alphabetically
+; Solr[author_facet] = "index=sort_alphabetic"
+
+; These settings affect the way the [Results] facets are displayed
+; If using facets at the top of search results you have more room for text.
+[Results_Settings]
+; By default, how many values should we show for each facet? (-1 for no limit)
+facet_limit = 30
+; Override facet_limit on a per-field basis using this array:
+;facet_limit_by_field[format] = 50
+facet_limit_by_field[ixtheo_notation_facet] = -1
+facet_limit_by_field[dewey-hundreds] = -1
+facet_limit_by_field[dewey-tens] = -1
+facet_limit_by_field[dewey-ones] = -1
+; Limit facets based on a prefix on a per-field basis:
+;facet_prefix_by_field[building] = 22
+
+; Filter facet values to those matching a regular expression on a per-field basis:
+;facet_matches_by_field[era_facet] = ".+0"
+
+; By default, the side facets will only show 6 facets and then the "show more"
+; button. This can be configured with the showMore settings. A positive value is
+; required for "normal" facets, but for hierarchical facets you can use 0 to disable
+; truncation and always show all available values.
+; You can use the showMore[*] setting to set a new default setting.
+showMore[*] = 3
+; ...Or you can set a facet specific value by using the facet name as index.
+;showMore[format] = 10
+
+; Show more facets in a lightbox (paginated, no limit)
+; If false, facets expand in side bar to show facets up to the above limit
+; If "more", facets expand and offer an option at the bottom to open the lightbox
+; If true, facets immediately open in the lightbox
+showMoreInLightbox[*] = true
+lightboxLimit = 500 ; page size for the lightbox
+
+; Number of rows of values for top facets to show above the "more" button
+top_rows = 2
+top_cols = 3
+; Should we show "exclude" links for some or all of the facets? Set to * for
+; all facets, use a comma-separated list to show for some of the facets, set
+; to false or omit to disable "exclude" links
+;exclude = *
+; Should we OR together facets rather than ANDing them? Set to * for
+; all facets, use a comma-separated list to apply to some of the facets, set
+; to false or omit to disable ORed facets.
+orFacets = mediatype,format,language,ixtheo_notation_facet,geographic_facet,author_facet,publisher_facet,dewey-hundreds
+; Do we want any facets to be collapsed by default?
+;collapsedFacets = *
+
+; This can be used to sort specific facet fields alphabetically by index value
+; (which normally results in alphabetical order).
+; Please note: This sorts natively in the Solr index using untranslated values,
+; so if you are using facet translation, your values may not always display in
+; the expected order.
+sorted_by_index[] = ixtheo_notation_facet
+sorted_by_index[] = dewey-hundreds;
+sorted_by_index[] = dewey-tens
+sorted_by_index[] = dewey-ones
+
+; Enable JS feature to select multiple facets without reloading the result page
+; default : false (behaviour disabled)
+;multiFacetsSelection = true
+
+; The author home screen has different facets
+[Author]
+topic_facet = "Related Subjects"
+
+; These facets will be displayed as limiters on the advanced search search screen
+; NOTE: To make changes take effect immediately, you may need to clear VuFind's
+; cache after changing this section.
+[Advanced]
+ixtheo_notation_facet = "IxTheo Classification"
+;callnumber-first = "Call Number"
+language         = Language
+format           = Format
+;hierarchy_top_title   = Collections
+
+; Most of these settings affect the way the [Advanced] facets are displayed; the
+; translated_facets setting affects facets globally.
+[Advanced_Settings]
+; How many values should we show for each facet? Note: you may need to clear your
+; $VUFIND_LOCAL_DIR/cache/objects directory to make changes to this setting take
+; effect immediately.
+localized_facet_filters[] = dewey-hundreds
+localized_facet_filters[] = ixtheo_notation_facet
+facet_limit      = -1      ; how many values should we show for each facet?
+; Should we OR together facets rather than ANDing them? Set to * for
+; all facets, use a comma-separated list to apply to some of the facets, set
+; to false or omit to disable ORed facets.
+orFacets = *
+; A default delimiter for use with delimited facets (see below).
+delimiter = "{{{_:::_}}}"
+
+; The facets listed under the [Advanced] section above will be used as limiters on
+; the advanced search screen and will be displayed uniformly as multi-select boxes.
+; Some facet types don't lend themselves to this format, and they can be turned on
+; by inclusion in the comma-separated list below, or turned off by being excluded.
+; Supported values:
+; checkboxes - displays a list of checkbox facets as specified in the
+;      [CheckboxFacets] section above. You can specify the config file/section
+;      with colon-separated parameters following the checkboxes setting; e.g.
+;      checkboxes:facets:myCustomCheckboxes will load from the myCustomCheckboxes
+;      section of facets.ini. You can prefix the section name with a tilde (~)
+;      to reverse processing of the section to label => filter format (useful if your
+;      filters contain values that are illegal in configuration keys -- e.g. []).
+; daterange - for the range controls specified by the dateRange setting under
+;      [Special_Facets] above; if multiple fields are specified above but you
+;      only want certain ones on the advanced screen, you can filter with a
+;      colon separated list; e.g. "daterange:field1:field2:field3"
+; fulldaterange - just like daterange above, but for fullDateRange[] fields.
+; genericrange - just like daterange above, but for genericRange[] fields.
+; illustrated - for the "illustrated/not illustrated" radio button limiter
+; numericrange - just like daterange above, but for numericRange[] fields.
+special_facets   = "daterange"
+
+; Any facet fields named in the translated_facets[] list below will have their values
+; run through the translation code; values from unlisted facet fields will be
+; displayed as-is without translation.
+;
+; For translated facets, be sure that all of the necessary strings are included in the
+; language files found in the languages directory.
+;
+; You may add a colon and the name of a text domain after the field name to specify
+; translations in a specific text domain (subdirectory of the languages folder).
+;
+; If you add a second colon, you may add a  translation string containing the
+; placeholders %%raw%% and %%translated%%. You can enter the translation string
+; directly (if the formatting is uniform for all languages), or you can use a key
+; pointing to values found in the language files (if you need different formatting
+; for different languages). This can be useful if the facet is related to a
+; classification and you would like to show the raw value together with the
+; translation (see the Dewey example below for a possible application).
+;
+; Commenting out all translated_facets[] lines below will disable facet translation.
+;
+; Please note that the "filter" textbox control in the expanded facet list
+; will be disabled for translated facets due to technical limitations of its
+; implementation. Filtering can only be applied to raw values in the index.
+;TueFind: if you only want to translate "[Unassigned]", please use the translated_facets_unassigned section instead!
+;translated_facets[] = institution
+;translated_facets[] = building
+translated_facets[]   = format
+translated_facets[]   = is_open_access
+translated_facets[]   = language
+translated_facets[]   = mediatype
+; If you change the default Dewey indexing to omit translation mapping at index time,
+; you can uncomment the below configuration to take advantage of on-the-fly
+; translation into multiple languages.
+;translated_facets[] = dewey-ones:DDC23:%%raw%% - %%translated%%
+;translated_facets[] = dewey-tens:DDC23:%%raw%% - %%translated%%
+;translated_facets[] = dewey-hundreds:DDC23:%%raw%% - %%translated%%
+
+; TueFind-specific
+; This is needed for facets where we only want to translate the "unassigned" entry.
+; We don't want this in the default translated_facets section, since this would also
+; lead to e.g. filtering mechanisms being disabled.
+translated_facets_unassigned[] = author_facet
+translated_facets_unassigned[] = publisher_facet
+
+; Any facets named here will be treated as a delimited facet.
+; Delimited facets can be used to display a text value for otherwise incomprehensible
+; facet values. It can also be used in combination with sorted_by_index (above)
+; to fully control the display order of facet values. The delimiter may be present in
+; the string an unlimited number of times; only the text after the last delimiter
+; will be displayed to the user.
+; e.g. facetValue{{{_:::_}}}displayText
+; e.g. sortKey{{{_:::_}}}facetValue{{{_:::_}}}displayText
+; Per-field delimiters can be set here following a pipe after the facet name.
+; e.g. "author_id_str|:::"
+; If no delimiter is set, the default delimiter (set above) will be used.
+;delimited_facets[] = author_id_str
+;delimited_facets[] = "author_id_str|:::"
+
+; Sort overrides for Advanced search hierarchical facets. See the comments
+; above the SpecialFacets > hierarchicalFacetSortOptions setting for details.
+;hierarchicalFacetSortOptions[*] = all
+;hierarchicalFacetSortOptions[building] = top
+
+; These facets will be displayed on the Home Page when FacetList is turned on in
+; the content setting of the [HomePage] section of searches.ini. If this section
+; is omitted, the [Advanced] section will be used instead.
+
+; Override the alphabetical sorting for individual facets and display them at the
+; top of the limits on the advanced search page. As an example, this could be used
+; to display the most commonly searched languages above the rest. All following
+; limits display in the natural sorted order.
+;limitOrderOverride[language] = Icelandic::English::Spanish
+;limitOrderOverride[format] = CD::DVD
+
+; Optional delimiter to use in the limitOrderOverride settings above. When enabled,
+; limits must be separated using the same character set here.
+;limitDelimiter = "::"
+
+; Optional setting to enable HierarchicalFacetFilters
+; and HierarchicalExcludeFilters for advanced search facets.
+;enable_hierarchical_filters = true
+
+[HomePage]
+;callnumber-first = "Call Number"
+;language         = Language
+;format           = Format
+;hierarchy_top_title   = Collections
+
+; These settings affect the way the [HomePage] facets are displayed.
+; NOTE: To make changes take effect immediately, you may need to clear VuFind's
+; cache after changing this section.
+[HomePage_Settings]
+; how many values should we load for each facet?  depending on the column layout
+; of the homepage facet lists, we may not display all loaded values for every facet
+facet_limit      = 20
+
+; By default, the New Items screen will use the [Advanced] and [Advanced_Settings]
+; sections above, but you can override this by uncommenting the sections below as
+; needed. New Items facets also need to be enabled in searches.ini for this to work.
+;[NewItems]
+;[NewItems_Settings]
+
+; Sort overrides for HomePage search hierarchical facets. See the comments
+; above the SpecialFacets > hierarchicalFacetSortOptions setting for details.
+;hierarchicalFacetSortOptions[*] = all
+;hierarchicalFacetSortOptions[building] = top
+
+[Visual_Settings]
+; Which two facetable fields should be used for creating the visual results?
+; See VisualFacets recommendation module in searches.ini for more details.
+visual_facets = "callnumber-first,topic_facet"
+
+; If you rename a facet field, you can map the old value to a new value in this
+; section to ensure that legacy URLs continue to function.
+[LegacyFields]
+
+; Prevent specific facet values from being displayed to the user.
+; Use facet field names as keys and untranslated facet values as values.
+[HideFacetValue]
+;format[] = "Book"
+
+; Prevent all but specific facet values from being displayed to the user.
+; Use facet field names as keys and untranslated facet values as values.
+[ShowFacetValue]
+;format[] = "Book"
+
+; This section can be used to define custom filters, where a simple value
+; in the VuFind URL gets remapped to a more complex filter in the Solr
+; request, or where special Solr filters are applied UNLESS a simple value
+; is added to the VuFind URL
+;
+; This can be useful in combination with checkbox filters and hidden filters
+; if you wish to define filters that are too complex to easily represent in
+; .ini file syntax, and it also makes URLs more readable and easier to share.
+[CustomFilters]
+; This is the name of the virtual Solr field used when applying custom
+; filters. For example, if you define an inverted filter named include_books
+; below, and your custom filter field was the default of vufind, you
+; would add &filter[]=vufind:include_books to the URL in order to apply
+; the inverted filter.
+custom_filter_field = "vufind"
+
+; The translated_filters setting is an array where keys are the values used
+; in combination with custom_filter_field in VuFind URLs, and the values are
+; the actual filters applied to Solr.
+;translated_filters[book_or_journal] = 'format:("Book" OR "Journal")'
+
+; The inverted_filters setting is formatted like translated_filters, but the
+; filtering behavior is inverted. These filters will ALWAYS be applied to Solr
+; UNLESS the custom filters are applied by the user. This is useful in
+; combination with checkbox facets if you want to exclude values by default
+; and provide a checkbox that allows them to be included.
+;inverted_filters[include_books] = '-format:"Book"'
+
+; Exclude filters can be specified to exclude certain filters from showing in hierarchical
+; facets. These settings will apply to the search results facets by default.
+; To enable them in advanced search facets, see enable_hierarchical_filters in
+; Advanced_Settings.
+;[HierarchicalExcludeFilters]
+;building[] = 0/<Building>/
+;format[] = 1/Book/BookPart
+
+; Facet filters can be specified to limit hierarchical facet display to given values.
+; If no values are specified on a facet level, all items for the level are displayed.
+; These settings will apply to the search results facets by default.
+; To enable them in advanced search facets, see enable_hierarchical_filters in
+; Advanced_Settings
+;[HierarchicalFacetFilters]
+;building[] = 0/<Building>/
+;format[] = 0/Book/

--- a/local/tuefind/instances/augustine/config/vufind/fulltextsnippet.ini
+++ b/local/tuefind/instances/augustine/config/vufind/fulltextsnippet.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/fulltextsnippet.ini

--- a/local/tuefind/instances/augustine/config/vufind/local_overrides
+++ b/local/tuefind/instances/augustine/config/vufind/local_overrides
@@ -1,0 +1,1 @@
+../../../../local_overrides

--- a/local/tuefind/instances/augustine/config/vufind/metadata.ini
+++ b/local/tuefind/instances/augustine/config/vufind/metadata.ini
@@ -1,0 +1,14 @@
+; This file controls the export of HTML meta headers on the Record page.
+;
+; The amount of exported metadata depends on field availability
+; as well as the implementation of the chosen RecordDriver.
+; (e.g. \VuFind\RecordDriver\DefaultRecord implements getContainerTitle(),
+; but in case of SolrMarc the referenced "container_title" field
+; is not indexed by default).
+;
+[Vocabularies]
+;VuFind\RecordDriver\SolrMarc[] = BEPress
+;VuFind\RecordDriver\SolrMarc[] = DublinCore
+;VuFind\RecordDriver\SolrMarc[] = Eprints
+VuFind\RecordDriver\SolrMarc[] = HighwirePress       ; recommended for Google Scholar
+;VuFind\RecordDriver\SolrMarc[] = PRISM

--- a/local/tuefind/instances/augustine/config/vufind/searchbox.ini
+++ b/local/tuefind/instances/augustine/config/vufind/searchbox.ini
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/searchbox.ini

--- a/local/tuefind/instances/augustine/config/vufind/searches.ini
+++ b/local/tuefind/instances/augustine/config/vufind/searches.ini
@@ -1,0 +1,952 @@
+; This section contains global settings affecting search behavior.
+[General]
+default_handler      = AllFields    ; Search handler to use if none is specified
+
+; This setting controls the default sort order of search results if no search-
+; specific setting was present in the [DefaultSortingByType] section below; the
+; selected option should be one of the options present in the [Sorting] section
+; below.
+default_sort = relevance, year desc
+
+; This setting controls the default sort order of search results if multiple
+; records match the same value when records are sorted just using one field.
+; You can optionally include a direction (e.g. "id asc" or "id desc").
+; The selected field is used as a tie breaker to sort the matching results.
+tie_breaker_sort = id
+
+; This setting controls the sort order to be used for empty (or purely ID-based)
+; searches when relevance sort is selected. Since relevance doesn't have a
+; meaningful function without query terms, this can be set to e.g. "title" or
+; "year desc".
+;empty_search_relevance_override = title
+
+; This setting controls the default view for search results; the selected option
+; should be one of the options present in the [Views] section below.
+default_view         = list
+
+; This section controls the result limit options for search results. default_limit
+; sets the default number of results per page. limit_options is a comma-separated
+; list of numbers to be presented to the end-user. If only one limit is required,
+; set default_limit and leave limit_options commented out.
+; WARNING: using large limits may cause problems due to a variety of limitations,
+; especially if you support bulk operations (which can cause large URLs/requests).
+; If you must support large page sizes, you may need to raise the PHP memory_limit
+; and max_input_vars settings and/or adjust the Apache LimitRequestLine setting.
+default_limit        = 20
+limit_options        = 10,20,50,100,200,500
+
+; This setting allows to limit pagination of a search result as deep pagination
+; costs a lot of performance and most users are not very likely to navigate
+; further down than 20 pages of a search result.
+; This is especially useful to prevent webcrawlers from descending too deep and
+; eating up search backend performance. Default is set to unlimited.
+;result_limit = 400
+
+; If this setting is true, boolean operators in searches (AND/OR/NOT) will only
+; be recognized if they are ALL UPPERCASE.  If set to false, they will be
+; recognized regardless of case.  If set to a comma-separated list of operators
+; (e.g. "AND,NOT") then only the listed operators will be case-sensitive.
+case_sensitive_bools = true
+
+; If this setting is true, range operators in searches ([a TO b] or {a TO b})
+; will only be recognized if the word "TO" is ALL UPPERCASE.  Additionally, the
+; edges of the range may be treated in a case sensitive manner.  If set to false,
+; ranges will be recognized regardless of case -- this will allow better matching
+; at the cost of a bit of extra server-side processing.
+case_sensitive_ranges = true
+
+; These are the default recommendations modules to use when no specific setting
+; are found in the [TopRecommendations], [SideRecommendations] or
+; [NoResultsRecommendations] sections below.
+; See the comments above those sections for details on legal settings.  You may
+; repeat these lines to load multiple recommendations.
+;default_top_recommend[] = MapSelection ; see [MapSelection] in geofeatures.ini.
+;default_top_recommend[] = TopFacets:ResultsTop
+default_top_recommend[] = SpellingSuggestions
+;default_top_recommend[] = VisualFacets:Visual_Settings
+default_side_recommend[] = SideFacets:Results:CheckboxFacets
+; SideFacetsDeferred is an alternative to SideFacets. Using it will defer loading of
+; any facet until it's actually displayed. This can improve search performance and
+; decrease server load especially with larger indexes.
+;default_side_recommend[] = SideFacetsDeferred:Results:CheckboxFacets
+;default_noresults_recommend[] = SwitchTab
+default_noresults_recommend[] = Ids
+default_noresults_recommend[] = SwitchType
+default_noresults_recommend[] = SwitchQuery:::fuzzy
+default_noresults_recommend[] = SpellingSuggestions
+default_noresults_recommend[] = RemoveFilters
+
+; Set this to true in order to highlight keywords from the search query when they
+; appear in fields displayed in search results. Note: while this setting will
+; always prevent highlighting from displaying in your output, if you want to
+; prevent VuFind from requesting highlighting data from Solr, you must also turn
+; off the snippets setting below, since snippets depend on highlighting data.
+highlighting = false
+
+; Set this to restrict the list of fields that will be highlighted (the hl.fl
+; Solr parameter); default = '*' for all fields:
+;highlighting_fields = *
+
+; You can use this setting to add additional highlighting parameters to the Solr
+; request when highlighting as active. For all available options, see:
+;   https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
+;extra_hl_params[hl.bs.type] = LINE
+
+; Set this to true in order to include a text snippet in the search results when
+; a keyword match is found in a field that is not normally displayed as part of
+; the listing.  For finer control over which fields are used for snippets, see
+; the record driver code (web/RecordDrivers/IndexRecord.php).
+;
+; For control over snippet captions, see the [Snippet_Captions] section below.
+snippets = false
+
+; When you filter a search using facets, should VuFind retain your current filters
+; on the next search and provide a reset button to clear them (true), or should it
+; always perform new searches unfiltered (false)?
+retain_filters_by_default = true
+
+; Whether to always (when there are active filters) display the "Reset Filters"
+; button regardless of the retain_filters_by_default setting. Default is false.
+always_display_reset_filters = false
+
+; The filters listed below will be applied to all new searches by default. Omit
+; this setting to have no default filters applied. These differ from hidden
+; filters because they are visible in the UI and may be removed by the user.
+;
+; You can use complex filters (for example with boolean operators inside).
+; In order to do that, just set the filter into parentheses (as in the third sample line).
+;
+; NOTE: If you are setting a default filter on a field that is used for OR
+; facets (see the orFacets setting in facets.ini), be sure to prefix the field
+; name with a tilde (~)... e.g. "~format:Book"
+;default_filters[] = "format:Book"
+;default_filters[] = "institution:MyInstitution"
+;default_filters[] = "(format:Book AND institution:MyInstitution)"
+
+; Default record fields to fetch from Solr when searching (Solr parameter 'fl')
+; Default is "*" (since VuFind 7.0). When Explain is enabled 'score' will automatically be
+; added if it is not already included. To restore previous setting, just uncomment
+; line below.
+;default_record_fields = "*,score"
+
+; Whether the "versions" (FRBR) link and record tab are enabled. Default is true.
+; TueFind: Disable to avoid conflicts with Collapse & Expand
+display_versions = false
+
+; Default Solr parameters.
+;
+; Set sow=false in search to enable support for multiterm synonyms, but note the
+; caveats described at
+; https://opensourceconnections.com/blog/2018/02/20/edismax-and-multiterm-synonyms-oddities/
+;
+; Parameters are entered as query parameters and they can be repeated like in Solr's
+; query string syntax:
+; default_parameters[search] = "fq=field%3A%2Fmatch%2F&fq=another%3A2"
+;
+; Parameters can be defined for the following search contexts:
+; *                 All contexts
+; search            Search
+; retrieve          Retrieve records
+; similar           Find similar records
+; terms             Return terms
+; alphabeticBrowse  Return information from the browse index
+; workExpressions   Return work expressions (record versions)
+;default_parameters[*] = "echoParams=none&debugQuery=false"
+;default_parameters[search] = "sow=false"
+
+; If you set this setting, VuFind will use a secondary Solr field to try to find
+; previous record IDs when primary ID lookups fail. If you leave the setting
+; commented out, fallback ID lookups will be disabled.
+;fallback_id_field = previous_id_str_mv
+
+; This controls whether results are loaded with JavaScript when paging or changing
+; settings. Loading results this way improves performance and accessibility, and is
+; enabled by default. Loading will automatically fall back to non-JS mode if
+; JavaScript is not supported by the browser.
+load_results_with_js = true
+
+; This setting can be used to configure pagination control on top of results.
+; Possible options are:
+; empty string or false  No top pagination (default when load_results_with_js is
+;                        disabled)
+; simple                 Simple next/prev button pagination (default when
+;                        load_results_with_js is enabled)
+; full                   Full pagination alike to the one at the bottom of results
+;top_paginator = simple
+
+[Cache]
+; This controls whether the parsed searchspecs.yaml file will be stored to
+; improve search performance; legal options File (store on disk) or false (do not
+; cache).
+type = File
+
+; This section shows which search types will display in the basic search box at
+; the top of most pages.  The name of each setting below corresponds with a
+; search handler (either DisMax or from conf/searchspecs.yaml).  The value of
+; each setting is the text to display on screen.  All on-screen text will be run
+; through the translator, so be sure to update language files if necessary.  The
+; order of these settings will be maintained in the drop-down list in the UI.
+;
+; Note: The search type of "tag" is a special case that gets handled differently
+;       because tags are not stored in the same index as everything else.  Treat
+;       this as a reserved word if you create your own custom search handlers.
+[Basic_Searches]
+AllFields           = "All Fields"
+Title               = Title
+;JournalTitle        = "Journal Title"
+Author              = Author
+Subject             = Subject
+CallNumber          = "Call Number"
+ISN                 = "ISBN/ISSN"
+BibleRangeSearch    = "Bible Ranges"
+CanonesRangeSearch  = "Canones Range Search"
+;Coordinate        = Coordinates
+;tag                 = Tag
+
+; This section defines which search options will be included on the advanced
+; search screen.  All the notes above [Basic_Searches] also apply here.
+[Advanced_Searches]
+AllFields           = adv_search_all
+Title               = adv_search_title
+;JournalTitle        = adv_search_journaltitle
+Author              = adv_search_author
+Subject             = adv_search_subject
+CallNumber          = adv_search_callnumber
+ISN                 = adv_search_isn
+publisher           = adv_search_publisher
+Series              = adv_search_series
+year                = adv_search_year
+toc                 = adv_search_toc
+BibleRangeSearch    = "Bible Ranges"
+CanonesRangeSearch  = "Canones Range Search"
+;Coordinate        = Coordinates
+
+
+; This section defines the sort options available on standard search results.
+; Values on the left of the equal sign are either the reserved term "relevance"
+; or the name of a Solr index to use for sorting; asc and desc modifiers may be
+; used in combination with index names, but not relevance.  To allow secondary
+; sorting, you may include a comma-separated list of options (for example,
+; "year desc,title asc"), but this list may NOT include the special "relevance"
+; value.  Values on the right of the equal sign are text that will be run
+; through the translation module and displayed on screen.
+;
+; Note: "year", "author" and "title" are special shortcut aliases for the
+;       "publishDateSort", "author_sort" and "title_sort" Solr fields; you can
+;       use either form in this file.
+[Sorting]
+relevance, year desc = sort_relevance
+year desc, volume_sort desc, issue_sort desc, start_page asc, first_indexed desc = sort_year
+year asc, volume_sort asc, issue_sort asc, start_page asc = "sort_year asc"
+
+; Use the "callnumber-sort" line for LC or the "dewey-sort" line for Dewey Decimal.
+; If you want to enable both systems for sorting, you can uncomment both lines,
+; but you will need to add some custom text to distinguish between the two.
+;callnumber-sort = sort_callnumber
+;dewey-sort = sort_callnumber
+
+author = sort_author
+title = sort_title
+
+; This section allows you to specify the default sort order for specific types of
+; searches.  Each key in this section should correspond with a key in the
+; [Basic_Searches] section above.  Each value should correspond with a key in the
+; [Sorting] section above.  Any search type that is not listed here will be sorted
+; using the default_sort setting in the [General] section above.
+[DefaultSortingByType]
+CallNumber = callnumber-sort
+WorkKeys = year
+BibleRangeSearch = relevance, year desc
+SubjectAutosuggest = relevance
+Subject = year desc, volume_sort desc, issue_sort desc, start_page asc, first_indexed desc
+
+; This section allows you to specify hidden sorting options. They can be used to create a
+; whitelist of sort values using regular expressions. If you want to do this add regexes to
+; the pattern[] array. All sort values that match at least one of these pattern are allowed
+; in searches. But they will not be shown in the sort selection in the result list.
+[HiddenSorting]
+;pattern[] = .* ; E.g. uncomment this line to allow any value
+
+; Each search type defined in searchspecs.yaml can have one or more "recommendations
+; modules" associated with it in the following sections.  These plug-ins will cause
+; boxes of suggestions to appear beside (in [SideRecommendations]) or above (in
+; [TopRecommendations]) the search results.  The special [NoResultsRecommendations]
+; are only displayed for empty search results.  You can repeat the line to display a
+; series of recommendations boxes in a particular section -- just be sure to include
+; brackets ("[]") after the search type name.  If you do not want recommendations
+; for a particular search type, set the value to "false" in either or both sections.
+; Any search types not listed here will use the default value -- see the
+; default_top_recommend and default_side_recommend settings in the [General]
+; section above.  It is legal to set the default options to false if you want no
+; default value.
+;
+; Available modules recommended for use in the side area:
+;
+; CatalogResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display catalog search results matching the terms found in the specified
+;       GET parameter (default = "lookfor"), limited to a specified number of
+;       matches (default = 5). This is designed for use with non-catalog modules.
+;       The optional custom heading overrides the default for this recommendation.
+;       Filters may be defined in the specified section of the searches.ini
+;       file; see [CatalogResultsVideoFilter] below for an example of this.
+;       Finally, a custom sort order can be specified.
+; CatalogResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]
+;       Same as CatalogResults, but loaded via AJAX.
+; ConsortialVuFind:[requestParam]:[limit]:[ini section]
+;       Display and link to results in an external, consortial instance of VuFind,
+;       such as a ReShare-hosted catalog. See ConsortialVuFind.ini for details, and
+;       configure in the section of that file referenced by "ini section". Display
+;       search results matching the terms found in the specified GET parameter
+;       (default = "lookfor"), limited to a specified number of matches
+;       (default = 5). Results are cached; the cache can be disabled or configured in
+;       the [Cache_ExternalVuFind_Defaults] section of ExternalVuFind.ini.
+; ConsortialVuFindDeferred:[requestParam]:[limit]:[ini section]
+;       Same as ConsortialVuFind, but loaded via AJAX.
+; Databases:[result limit]:[ini name]
+;       Displays a list of the databases referenced in EDS or similar facets, each
+;       linking to its individual website.  The .ini file must contain a [Databases]
+;       section with the relevant configuration; see example in EDS.ini.
+; DPLATerms:[collapsed]
+;       Display results from the DPLA catalog. Provide a boolean to have the sidebar
+;       collapsed or open on page load.
+; EDSResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display EDS search results matching. See CatalogResults above for parameter
+;       definitions. The [filter ini section] parameter refers to a section in EDS.ini.
+; EDSResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Same as EDSResults, but loaded via AJAX.
+; EPFResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display EPF (EBSCO Publication Finder) search results. See CatalogResults above
+;       for parameter definitions. The [filter ini section] parameter refers to a section in
+;       EPF.ini. The [sort] parameter is not currently supported for this backend.
+; EPFResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Same as EPFResults, but loaded via AJAX.
+; EuropeanaResults:[url]:[requestParam]:[limit]:[unwanted data providers]
+;       Display search results from Europeana.eu API.
+;       Parameters (all are optional):
+;         [url] = base search URL, default api.europeana.eu/api/v2/opensearch.rss
+;         [requestParam] = parameter name for passing lookup value in url, default is
+;             "searchTerms"
+;         [limit] = the number of result items to display (defaults to 5)
+;         [unwanted data providers] = comma separated list of dataproviders to ignore
+;             results from; useful for excluding your own results that are also in
+;             Europeana.
+;       An API key must be set in config.ini (see europeanaAPI setting in [Content]
+;       section).
+; EuropeanaResultsDeferred:[url]:[requestParam]:[limit]:[unwanted data providers]
+;       See EuropeanaResults, but this version uses AJAX for asynchronous loading.
+; ExpandFacets:[ini section]:[ini name]
+;       Display facets listed in the specified section of the specified ini file;
+;       if [ini name] is left out, it defaults to "facets."  Rather than using
+;       facets to limit the existing search, this module uses them to start a new
+;       search showing all records matching the selected facet value.
+; FacetCloud:[ini section]:[ini name]
+;       Same functionality as ExpandFacets, but with a more compact interface to
+;       allow the display of more values.
+; LibGuidesProfile
+;       Display a single LibGuides Profile for a LibGuides user (likely a librarian)
+;       who owns a subject guide whose title most closely matches the search terms.
+;       Uses configuration in LibGuidesAPI.ini and requires configuration in
+;       contentsecuritypolicy.ini.
+; LibGuidesResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display LibGuides research guides search results. See CatalogResults above
+;       for parameter definitions. Note that [filter ini section] and [sort] have
+;       no effect on this backend.
+; LibGuidesResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Same as LibGuidesResults, but loaded via AJAX.
+; LibGuidesAZResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display LibGuides A-Z Databases search results. See CatalogResults above
+;       for parameter definitions. Note that [filter ini section] and [sort] have
+;       no effect on this backend.
+; LibGuidesAZResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Same as LibGuidesAZResults, but loaded via AJAX.
+; OpenLibrarySubjects:[GET parameter]:[limit]:[date filter]:[Subject types]
+;       Display full-text, public scans from the Open Library (OL) Subjects API.
+;       [GET parameter] (default = "lookfor"), [limit] (default = 5),
+;       [date filter] The name of a date filter (from facet settings) to apply to
+;           searches.  Defaults to "publishDate" if blank; set to "false" to disable.
+;       [Subject types] (default = "topic") comma-separated list of subject types to
+;           test. Open Library distinguishes between the following subject types:
+;           topic,place,person,time
+;       Note: an API call will be made for each type until valid data is returned
+;           which will slow down the loading of the main VuFind result set,
+;           see OpenLibrarySubjectsDeferred
+; OpenLibrarySubjectsDeferred:[GET parameter]:[limit]:[date filter]:[Subject types]
+;       The same as OpenLibrarySubjects but uses AJAX to make the API calls after the
+;           main result set has loaded
+; RandomRecommend:[backend]:[limit]:[display mode]:[random mode]:[minimumset]
+;        :[facet1]:[facetvalue1]:[facet2]:[facetvalue2]:...:[facet-n]:[facetvalue-n]
+;       This module offers random records either from the whole backend or within
+;       the current resultset.
+;       [backend] is the name of the search backend currently in use,
+;       which will help with accurate analysis (default = Solr)
+;       [limit] is the number of records to display (default = 10)
+;       [display mode] determines how the records are displayed. Valid values are
+;       "standard" (for a basic display including titles and authors),
+;       "images" for just images or "mixed" for both. (default = standard)
+;       [random mode] determines if the records are selected from the entire backend
+;       or from the current result set. Valid values are "retain" to limit results
+;       to the current result set or "disregard" to use the entire backend.
+;       (default = retain)
+;       [minimumset] is the minimum result set count required to display random items,
+;       0 = no minimum required. This setting can be used to prevent random items
+;       displaying in a small result set. (default = 0)
+;       [facet-n] A facet to apply to the random selection
+;       [facetvalue-n] The facet value to apply to the random selection
+; SideFacets:[regular facet section]:[checkbox facet section]:[ini name]
+;       :[include dynamic checkboxes]
+;       Display the specified facets, where [ini name] is the name of an ini file
+;       in your config directory (defaults to "facets" if not supplied),
+;       [regular facet section] is the name of a section of the ini file containing
+;       standard facet settings (defaults to "Results" if not specified),
+;       [checkbox facet section] is the name of a section of the ini file
+;       containing checkbox facet settings (leave blank for no checkbox facets), and
+;       [include dynamic checkboxes] is a true/false value indicating whether or not
+;       to display dynamically-generated checkbox facets (it defaults to true, but
+;       if you use multiple instances of SideFacets to split up your display, you
+;       should set it to false in all but one of the instances to avoid duplication).
+;       Checkbox facets are normally in filter => label format; prefix the section
+;       name with ~ to reverse this and use label => filter format (useful if your
+;       filters contain values that are illegal in configuration keys -- e.g. []).
+;       Note that if you take advantage of this ~ feature, you will also need to
+;       adjust the facets.ini Advanced_Settings/special_facets checkboxes setting
+;       in order to properly display checkboxes on the advanced search screen.
+; SpellingSuggestions
+;       Display spelling suggestions (also requires Spelling settings to be turned
+;       on in config.ini).
+; SummonBestBets:[GET parameter]
+;       Display Summon-generated "best bets" recommendations matching the terms found
+;       in the specified GET parameter.  NOTE: If you are using this module with a
+;       Summon search, the [GET parameter] setting will be ignored and the actual
+;       current Summon search will be used instead.  The parameter only needs to be
+;       specified when combining this module with a non-Summon-based search module.
+; SummonBestBetsDeferred:[GET parameter]
+;       Same as SummonBestBets, but loaded via AJAX.
+; SummonDatabases:[GET parameter]
+;       Display Summon-generated database recommendations matching the terms found
+;       in the specified GET parameter.  NOTE: If you are using this module with a
+;       Summon search, the [GET parameter] setting will be ignored and the actual
+;       current Summon search will be used instead.  The parameter only needs to be
+;       specified when combining this module with a non-Summon-based search module.
+; SummonDatabasesDeferred:[GET parameter]
+;       Same as SummonDatabases, but loaded via AJAX.
+; SummonResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display Summon search results. See CatalogResults above for parameter
+;       definitions. The [filter ini section] parameter refers to a section in Summon.ini.
+; SummonResultsDeferred:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Same as SummonResults, but loaded via AJAX.
+; SummonTopics:[GET parameter]
+;       Display Summon-generated topic recommendations matching the terms found
+;       in the specified GET parameter.  NOTE: If you are using this module with a
+;       Summon search, the [GET parameter] setting will be ignored and the actual
+;       current Summon search will be used instead.  The parameter only needs to be
+;       specified when combining this module with a non-Summon-based search module.
+; WebResults:[GET parameter]:[result limit]:[custom heading]:[filter ini section]:[sort]
+;       Display website search results. See CatalogResults above for parameter
+;       definitions. The [filter ini section] parameter refers to a section in website.ini.
+;
+; Available modules recommended for use in the top area:
+;
+; AuthorFacets
+;       Display author names based on the search term.
+; AuthorInfo:[use_viaf]
+;       Load author information from external providers based on the current search
+;       and the "authors" setting in the [Content] section of config.ini.
+;       The [use_viaf] setting may be set to true to use the VIAF web service in
+;       combination with your Solr authority index to pick more appropriate authors;
+;       this defaults to false if unset.  If you do not have local authority records
+;       to draw on, the OCLC FAST data works well with the [use_viaf] option; see:
+;       https://vufind.org/wiki/indexing:open_data_sources#oclc_fast
+; AuthorityRecommend:[field1]:[query1]:[field2]:[query2]:...:[field-n]:[query-n]
+;       Displays see and see also results to user based on search of Authority Index.
+;       Any number of filter queries may be specified as parameters to limit which
+;       set of authority records is used for recommendations; for example:
+;           AuthorityRecommend:record_type:Heading* OR Topical*:source:FAST
+;       limits record_type to strings starting with "Heading" or "Topical" and
+;       limits source to FAST. A special field name of "__resultlimit__" may be
+;       used to suppress authority results when the result set contains more items
+;       than the number specified as the corresponding value (e.g. if you configure
+;       AuthorityRecommend:__resultlimit__:50 then authority recommendations will
+;       only display on result screens displaying fewer than 50 hits; by default,
+;       recommendations will always display). A special field name of "__mode__"
+;       may be used to control what type of suggestions are presented (default is
+;       both seealso and usefor results, but you can turn on just one of these
+;       options if desired; for example "__mode__:seealso" would only show "see
+;       also" results from records whose main headings match the current search
+;       terms while "__mode__:usefor" would show only main headings from records
+;       whose "use for" headings match the current search. You can use "__mode__:*"
+;       to turn on all options (but this is default behavior if no __mode__ is
+;       set). Filtering is optional. A special field name of "__header__" may be
+;       used to customize the header text above the results (default = "See also").
+; Channels
+;       Display a link to the Channeled Browse functionality leading to channels of
+;       records related to the current search.
+; MapSelection
+;       Enable geographic searching capability by activating this module.
+;       Records must be indexed using the geographic search and display fields.
+;       See the marc_local.properties file for more information on indexing.
+;       See the [MapSelection] section of the geofeatures.ini file for more information.
+; PubDateVisAjax:[zooming]:[facet field 1]:[facet field 2]:...:[facet field n]
+;       Display a visualization of publication dates for each of the specified facet
+;       fields.  This is designed for a field containing four-digit years.  Zooming
+;       is set to either true or false and controls whether or not selecting part of
+;       the graph zooms in to greater detail.
+; TopFacets:[ini section]:[ini name]
+;       Display facets listed in the specified section of the specified ini file;
+;       if [ini name] is left out, it defaults to "facets."
+; VisualFacets:[ini section]:[ini name]
+;        Supports visualizing pivot facet information as a treemap or circle
+;        packing visualization. It must be used in combination with the "visual"
+;        view in the [Views] section below -- it will only display in Visual mode.
+;        [ini section] and [ini name] control where the module will load field
+;        configurations from; it defaults to Visual_Settings in facets.ini.
+;
+; Available modules recommended for use in the "no results" area:
+;
+; AlphaBrowseLink:index
+;       Use the query to generate a link to the specified alphabrowse index
+; DOI:[prefix]:[redirect_exact_match]
+;       Detect DOIs in the user search query. If a DOI makes up part of the search,
+;       display a link to resolve it. If it makes up the entire query, redirect to
+;       the resolver automatically. [prefix] is the URL of the resolver to which
+;       the DOI itself will be appended. [redirect_exact_match] is a boolean; set it
+;       to true if you want a search query that consists only of a DOI to redirect
+;       automatically to the DOI resolver, or set it to false to only display a
+;       message with a link. (Default is "true").
+; ExternalSearch:[link label]:[url template]
+;       Display a link to an external search system. The contents of the <a> tag
+;       will be [link label] (which will be run through the translator -- use a
+;       translation string if you need to display a string containing a colon).
+;       The href will be [url template] with %%lookfor%% replaced with the current
+;       search's lookfor parameter. If you omit the %%lookfor%% placeholder, the
+;       search terms will simply be appended to the end of the URL template.
+; Libraryh3lp:[type]:[id]:[skin]
+;       Display a chat box for the Libraryh3lp service. [type] indicates the type
+;       of chat being used (either "queue" or "user"). [id] is the name of the
+;       queue or user. [skin] is optional and specifies a skin number to use.
+; RecommendLinks:[ini section]:[ini name]
+;       Display a list of recommended links, taken from [ini section] in
+;       [ini name], where the section is a mapping of label => URL. [ini name]
+;       defaults to searches.ini, and [ini section] defaults to RecommendLinks.
+; RemoveFilters
+;       Suggests removing facet filters to retrieve more results.
+; SwitchQuery:[backend]:[opt-out checks to skip]:[opt-in checks to add]
+;       This module analyzes the user's query and offers suggestions for ways to
+;       improve it. [backend] is the name of the search backend currently in use,
+;       which will help with accurate analysis (default = Solr). [opt-out checks
+;       to skip] is a comma-separated list of checks which are on by default but
+;       which you wish to disable. [opt-in checks to add] is a comma-separated
+;       list of transforms that are off by default but which you wish to enable.
+;       See the check*() methods in the module's code for a complete list of
+;       available checks. The $optInMethods property specifies which checks are
+;       turned off by default.
+; SwitchTab
+;       If multiple tabs are active, suggest that the user try searching in a
+;       different one.
+; SwitchType:[field]:[field description]
+;       If the current search type is not the same as [field], display a link
+;       suggesting that the user try switching to [field].  [field description]
+;       is the human-readable description of [field].  Default values are
+;       'AllFields' and 'All Fields' respectively.
+;
+; You can build your own recommendations modules if you wish.  See the developer's
+; guide here:
+;
+;       https://vufind.org/wiki/development:plugins:recommendation_modules
+[SideRecommendations]
+; No search-specific settings by default -- add your own here.
+;Subject[]          = SideFacets
+;Subject[]          = OpenLibrarySubjectsDeferred:lookfor:5:true:topic,place,person,time
+
+[TopRecommendations]
+Author[]            = AuthorFacets
+Author[]            = SpellingSuggestions
+;CallNumber[]        = "TopFacets:ResultsTop"    ; disable spelling in this context
+; Do not show top recommendations for the Versions (WorkKeys) search by default
+WorkKeys[]          = false
+
+[NoResultsRecommendations]
+; dont show recommendations in BibleRangeSearch
+BibleRangeSearch[] = BibleRanges
+BibleRangeSearch[] = SwitchType
+CallNumber[] = SwitchQuery::wildcard:truncatechar
+;CallNumber[] = RemoveFilters
+;CallNumber[] = AlphaBrowseLink:lcc
+WorkKeys[]   = false
+
+; These settings control the top and side recommendations within the special Author
+; module (the page accessed by clicking on an author's name within the search
+; results).  The Author module ignores the default_top_recommend and
+; default_side_recommend settings and only uses this section.
+[AuthorModuleRecommendations]
+;top[] = TopFacets:ResultsTop
+;side[] = SideFacets:Results:CheckboxFacets
+top[] = AuthorInfo
+side[] = "SideFacets"
+
+; This is the default section used for setting up links for the RecommendLinks
+; recommendation module (see above for details).
+;[RecommendLinks]
+;Library of Congress Online Catalog = http://catalog.loc.gov/
+
+; This section controls the "New Items" search.
+[NewItem]
+; New item information can be retrieved from Solr or from the ILS; this setting
+; controls which mechanism is used. If using Solr, change tracking must be enabled
+; (see https://vufind.org/wiki/indexing:tracking_record_changes). If using the ILS,
+; your driver must support the getNewItems() method.
+; Valid options: ils, solr; default: ils
+method = solr
+; Comma-separated list of date ranges to offer to the user (i.e. 1,5,30 = one day
+; old, or five days old, or thirty days old). If using the "ils" method, be careful
+; about raising the maximum age too high -- searching very long date ranges may put
+; a load on your ILS.
+ranges = 7,14,30,60
+; This setting only applies when using the "ils" method. It controls the maximum
+; number of pages of results that will show up when doing a new item search.
+; It is necessary to limit the number of results to avoid getting a "too many boolean
+; clauses" error from the Solr index (see notes at
+; https://vufind.org/jira/browse/VUFIND-128 for more details).  However, if you
+; set the value too low, you may get the same results no matter which range setting
+; is selected!
+result_pages = 10
+; The default sort to use (if different from the normally configured default).
+;default_sort = year
+; Set to true to include pre-filtering facet options. By default this will use the
+; same facet options as the Advanced search screen, but this behavior can be
+; overridden; see [NewItems] and [NewItems_Settings] in facets.ini.
+include_facets = true
+; This setting can be used to automatically apply filter queries to the New Item
+; results.  For example, you might want to filter out certain content types.  You
+; can add multiple filters by repeating the "filter[] =" line, or you can skip
+; filtering entirely by leaving the line commented out.
+; filter[] = "format:Book"
+
+; This section controls RSS feed behavior
+[RSS]
+; If set, this setting will override sort settings associated with RSS feeds.  This
+; allows you to ensure that newly added or changed items in your index appear at
+; the top of the feed.  Use "first_indexed desc" if you only want newly-added items
+; to be listed first.  Use "last_indexed desc" if you want newly-added-or-changed
+; items.  Comment out the whole setting if you do not want custom RSS sorting.
+; IMPORTANT: In order for first_indexed and last_indexed sorting to work properly,
+;            you need to index record change dates; see the Wiki page at
+;            https://vufind.org/wiki/indexing:tracking_record_changes
+sort = "last_indexed desc"
+
+; The following two sections control the behavior of the autocomplete drop-downs
+; associated with search boxes.  The [Autocomplete] section contains global default
+; settings, while the [Autocomplete_Types] section allows you to associate different
+; autocomplete handlers with different search handlers.
+;
+; The available autocomplete handlers are:
+;
+; Eds:[Mode]
+;       Use the EBSCO Discovery Service autocomplete handler (only intended to be
+;       used in the context of the EDS backend). [Mode] can be either "holdings" for
+;       title completion in PubFinder or "rawqueries" for completion of basic textual
+;       queries.
+; None
+;       Do not provide any suggestions.  You should use this handler if you want to
+;       disable suggestions for one search type while still providing suggestions
+;       for other search types.  To disable suggestions completely, it is better to
+;       use the "enabled" setting in the [Autocomplete] section.
+; SolrAuth:[Search Handler]:[Display Field]:[Sort Field]:[Filters]
+;       See Solr below -- this handler behaves exactly the same, except
+;       it uses the Solr authority data index rather than the bibliographic index,
+;       and its default [Display Field] value is "heading".
+; Solr:[Search Handler]:[Display Field]:[Sort Field]:[Filters]
+;       Perform a wildcarded search against [Search Handler], using the contents of
+;       [Display Field] (a comma-separated, priority-ordered field list) as
+;       suggestions and sorting by [Sort Field].  Any additional parameters at the
+;       end of the string are treated as an alternating sequence of field names and
+;       values for use as filters against the suggestion list.  All parameters are
+;       optional.  If omitted, [Search Handler] will use the default Solr field,
+;       [Display Field] will use "title", [Sort Field] will use relevance and no
+;       filters will be applied.
+; SolrCN
+;       A customized version of Solr designed for smart handling of
+;       call numbers using the custom CallNumber search handler.
+; Tag
+;       Provide suggestions from the local database of tags.
+; SolrPrefix:[Autocomplete field]:[Display field]
+;       Perform a search against [Autocomplete field] using the edge n-gram
+;       tokenizer. Each word in the user's query is handled as a prefix. Values
+;       from [Display field] will be displayed for matching records. It is
+;       recommended that you index values for this handler into fields of type
+;       "text_autocomplete" (which are available using the dynamic field suffix
+;       *_autocomplete). These values should also be copied into a separate
+;       field, preferably single-valued, for display purposes, because display
+;       of values by this option relies on faceting -- be sure to choose an
+;       appropriate field type, such as a simple _str field, to ensure correct
+;       display. For example, to switch title suggestions to use the edge n-gram
+;       method, you could index titles into a new dynamic title_autocomplete
+;       field, then change the Title configuration in [Autocomplete_Types] to:
+;       "SolrPrefix:title_autocomplete:title_sort" (note the use of title_sort
+;       for display, because it is a string field and thus suitable for faceting).
+;
+; You can build your own autocomplete modules if you wish.  See the developer's
+; guide here:
+;
+;       https://vufind.org/wiki/development:plugins:autosuggesters
+[Autocomplete]
+; Set this to false to disable all autocomplete behavior
+enabled = true
+; This handler will be used for all search types not covered by [Autocomplete_Types]
+default_handler = Solr
+; Auto-submit autocomplete on click or enter
+auto_submit = true
+; Query formatting rules for autocomplete, indexed by search handler name;
+; formatting_rule[*] defines a rule that is used by default if a more specific type
+; is not provided. Currently supported rules:
+; - phrase: Put the value in double quotes, and backslash-escape quotes in the phrase
+; - none:   Search for the term exactly as-is, with no manipulation.
+formatting_rule[*] = "phrase"
+formatting_rule[alphabrowse_author] = "none"
+formatting_rule[alphabrowse_lcc] = "none"
+formatting_rule[alphabrowse_title] = "none"
+formatting_rule[alphabrowse_topic] = "none"
+formatting_rule[tag] = "none"
+
+; In this section, set the key equal to a search handler from searchspecs.yaml and
+; the value equal to an autocomplete handler in order to customize autocompletion
+; behavior when that search type is selected.
+[Autocomplete_Types]
+Title = "Solr:Title"
+JournalTitle = "Solr:JournalTitle"
+Author = "Solr:Author:author,author2"
+Subject = "Solr:SubjectAutosuggest:topic_facet,genre_facet,geographic_facet,era_facet"
+CallNumber = "SolrCN"
+ISN = "Solr:ISN:isbn,issn"
+Coordinate = "None"
+tag = "Tag"
+alphabrowse_author = "None"
+alphabrowse_lcc = "None"
+alphabrowse_title = "None"
+alphabrowse_topic = "None"
+
+; When snippets are enabled, this section can be used to display captions based on
+; the Solr fields from which the snippets were obtained.  Keys are the names of Solr
+; fields and values are strings to display to the user.  Note that all displayed
+; strings are subject to translation and should be accounted for in the language
+; files found in web/lang if you are in a multilingual environment.  Fields that are
+; not listed in this section will be displayed without captions, so you can comment
+; out the whole section to disable captions.
+[Snippet_Captions]
+author2 = "Other Authors"
+contents = "Table of Contents"
+topic = "Subjects"
+container_title = "Journal Title"
+
+; This section allows sharding to be used to pull in content from additional Solr
+; servers.  All servers used in sharding must contain the same index fields needed
+; to satisfy queries sent to them AND they must all include different ID numbers!
+; Note that additional Solr configuration may also be required; see the "Configuring
+; the ShardHandlerFactory" section of this document for details:
+;    https://lucene.apache.org/solr/guide/7_7/distributed-requests.html
+; Leave this section commented out to disable sharding.
+; To use sharding, simply fill in lines using the format:
+; [display name of shard] = [URL of shard (without http://)]
+;[IndexShards]
+;Library Catalog = localhost:8983/solr/biblio
+;Website = localhost:8983/solr/website
+
+; This section allows you to set preferences for shards display.  You only need to
+; set these if you want to use shards.  See also the [StripFields] section below
+; if your shards have non-identical schemas.
+;[ShardPreferences]
+; This setting controls whether or not to display checkboxes to allow the user to
+; select which shard(s) to search (default if commented out = false)
+;showCheckboxes = true
+; These lines determine which shards are searched by default if the user hasn't
+; specified preferences using checkboxes (default if commented out = all shards):
+;defaultChecked[] = "Library Catalog"
+;defaultChecked[] = "Website"
+
+; Fields must be stripped if you have a field in your main index which is missing
+; from any index includable by shards.  This section can be ignored if you are
+; not using sharding or if all of your shards have identical schemas.
+;
+; Put in the fields to strip here in the following format:
+; shard name = fieldname,another fieldname,...
+[StripFields]
+
+; This section defines the view options available on standard search results.
+; If only one view is required, set default_view under [General] above, and
+; leave this section commented out.
+;
+; Note -- when using visual view, you must also turn on the VisualFacets
+; recommendation module in the top area.
+;[Views]
+;list = List
+;grid = Grid
+;visual = Visual
+
+; This section controls what happens when a record title in a search result list
+; is clicked. VuFind can either embed the full result directly in the list using
+; AJAX or can display it at its own separate URL as a full HTML page.
+; full - separate page (default)
+; tabs - embedded using tabs (see record/ajaxview-tabs.phtml)
+; accordion - embedded using an accordion (see record/ajaxview-accordion.phtml)
+; NOTE: This feature is incompatible with SyndeticsPlus content; please use
+;       regular Syndetics if necessary.
+[List]
+view=full
+
+; This section allows for adding hidden filters. Each filter will be translated
+; to format 'key:"value"' and added by Solr.php as a hidden filter (a facet that
+; is always applied but is not seen by the user).  This is useful if you use a
+; shared Solr index and need to display different subsets in different contexts
+; (for example, a union catalog with separate VuFind instances each member).
+[HiddenFilters]
+is_augustine = 1
+;institution = "MyInstitution"
+
+; This section is an alternative to [HiddenFilters] when you need to create more
+; advanced types of filters -- i.e. complex boolean queries.  Keys are ignored,
+; but increasing numeric values (1, 2, 3...) are recommended.  Values are fully-
+; formed filter queries.
+[RawHiddenFilters]
+;0 = "format:\"Book\" OR format:\"Journal\""
+;1 = "language:\"English\" OR language:\"French\""
+0 = "-exclude_ixtheo:true"
+
+; This section can get used to define conditional filters, i.e. filters
+; that are applied under certain conditions.
+; You can use a permission set as condition, which has to be defined in
+; permissions.ini.
+; Keys are ignored, but increasing numeric values (1, 2, 3...) are recommended.
+; Values need to be formatted using this schema:
+; [-]permission|filter-query
+; Prefixing the condition with a minus (-) means that the filter is applied
+; when the condition does not match (the permission is not granted).
+; The filter may be any filter query valid for Solr.
+; Examples:
+; -conditionalFilter.MyUniversity|format:Book
+; apply filter "format:Book" if permission conditionalFilter.MyUniversity
+; (from permissions.ini) is not granted
+; conditionalFilter.MyUniversity|format:Article
+; apply filter "format:Article" if permission conditionalFilter.MyUniversity
+; (from permissions.ini) is granted
+[ConditionalHiddenFilters]
+;0 = "-conditionalFilter.MyUniversity|format:Book"
+;1 = "conditionalFilter.MyUniversity|format:Article"
+
+; This section defines how records are handled when being fetched from Solr.
+[Records]
+; Boolean value indicating if deduplication is enabled. If true, deduplication is
+; enabled. If false, dedup records are filtered out. If unspecified, deduplication
+; support is completely disabled.
+;deduplication = true
+; Priority order (descending) for record sources (record ID prefixes separated
+; from the actual record by period, e.g. testsrc.12345)
+;sources = alli,testsrc
+
+; This section defines the default parameters for the geographic search
+; functionality found in the MapSelection recommendation module.
+; To enable this feature, uncomment the default_top_recommend[] = MapSelection
+; in the default recommendations section. To set the configuration settings
+; for this feature, adjust the parameters in the geofeatures.ini file.
+[MapSelection]
+; These configuration settings have been superseded by the geofeatures.ini file.
+; See the [MapSelection] section of the geofeatures.ini file for more information.
+
+; This section defines settings used to fetch similar records.
+[MoreLikeThis]
+; Boolean value indicating whether the newer MoreLikeThis query handler should be
+; used instead of the traditional MoreLikeThis component (default). Only the
+; MoreLikeThis query handler supports sharded indexes, but as of this writing, the
+; traditional component offers more nuanced relevance ranking. Results from these
+; methods may differ.
+;useMoreLikeThisHandler = true
+; If the MoreLikeThis handler is used, this setting can be used to adjust its
+; behavior. See https://cwiki.apache.org/confluence/display/solr/Other+Parsers#OtherParsers-MoreLikeThisQueryParser
+; for more information regarding the possible parameters.
+;params = "qf=title,title_short,callnumber-label,topic,language,author,publishDate mintf=1 mindf=1";
+; This setting can be used to limit the maximum number of suggestions. Default is 5.
+count = 20
+
+; This section controls the behavior of the Search/Home screen.
+[HomePage]
+; Content blocks can be selected from the list below:
+;
+; Channels:[source] - Display the homepage channels for the specified [source].
+; [source] defaults to Solr.
+;
+; FacetList:[source]:[column size] - Display a list of facet values
+; drawn from the [source] backend, with a maximum of [column size] values per
+; column. [source] defaults to Solr and [column size] defaults to 10.
+;
+; IlsStatusMonitor:[target] - Performs an AJAX health check of the ILS and
+; prepends a warning message to the HTML element identified by the jQuery selector
+; provided in [target] (which defaults to .searchHomeContent.
+;
+; Recommend:[backend]:[module_name]:[module_params] - Display a recommendation
+; module, using the parameter object for the specified backend (default = Solr);
+; this will not work for all recommendation modules, but may be especially
+; useful for, e.g., Deferred recommendations that do not rely on search results.
+;
+; TemplateBased:[template] - Display the content of template defined after colon.
+; The template could be in phtml or md (markdown) format and has to be saved in
+; ContentBlock/TemplateBased/ directory of your theme. You can use language code
+; filename suffixes to present the content in different languages. For example,
+; you could add "content[] = TemplateBased:foo" to the settings below, then create
+; a ContentBlock/TemplateBased/foo.phtml (or foo.md) file in your theme's templates
+; directory to provide default content. If you wanted a different version of the
+; page for the German language, you could create a foo_de.phtml or foo_de.md file,
+; and that version would be loaded when the user's language was set to German.
+;content[] = IlsStatusMonitor
+;content[] = FacetList
+content[] = Home
+; This section controls default behavior of the Search API.
+[API]
+; These permissions must be defined in permissions.ini to grant access to the API:
+recordAccessPermission = access.api.Record
+searchAccessPermission = access.api.Search
+
+; This is the maximum number of results that can be returned in a single response:
+maxLimit = 100
+
+; This section provides settings for optional caching of search requests. This
+; affects the primary Solr backend only; for caching of other backends, see the
+; appropriate backend-specific configuration files (Search2.ini, website.ini, etc.).
+[SearchCache]
+; Supported adapters: Memcached, Filesystem. Others may also work, but have not been
+; tested.
+;adapter = Memcached
+; Comma-separated list of servers for Memcached adapter:
+;options[servers] = "localhost:11211"
+; Cache directory for Filesystem adapter:
+;options[cache_dir] = "/tmp/search-cache"
+; Other options. See https://docs.laminas.dev/laminas-cache/storage/adapter/ for
+; documentation on options for different adapters.
+; ttl, Time to Live, i.e. cache entry life time in seconds. 300 seconds by default.
+;options[ttl] = 300
+
+; This example section provides filters for the CatalogResults recommendation
+; module.  The section name is specified in the recommendation module config.
+;[CatalogResultsVideoFilter]
+
+; Filters are defined as in [RawHiddenFilters] in order to handle more complex
+; filter combinations.
+;0 = "format:Video"
+
+; This section provides settings for the explain feature. When enabled the result
+; list contains links to the explanation why a title was found and how the relevance
+; is calculated.
+[Explain]
+; The explain feature is disabled by default. Uncomment the following line to enable it
+;enabled = true
+; The explanation is split into the main fields and a rest.
+; minPercent gives a lower bound for fields to be included. All fields with
+; a percentage lower than minPercent are summarized in the rest.
+;minPercent = 0
+; maxFields gives a upper bound for the number of main fields. Set negative for no boundary.
+;maxFields = -1
+; Number of decimal places to be displayed.
+;decimalPlaces = 2
+
+; IXTHEO ONLY
+; This section is used to configure options parsed by IxTheo module only.
+[IxTheo]
+; Limit BibleRangeSearch to default sorting only
+forceDefaultSortSearches[] = BibleRangeSearch

--- a/local/tuefind/instances/augustine/config/vufind/searchspecs.yaml
+++ b/local/tuefind/instances/augustine/config/vufind/searchspecs.yaml
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/searchspecs.yaml

--- a/local/tuefind/instances/augustine/config/vufind/searchspecs2.yaml
+++ b/local/tuefind/instances/augustine/config/vufind/searchspecs2.yaml
@@ -1,0 +1,1 @@
+../../../ixtheo/config/vufind/searchspecs2.yaml

--- a/local/tuefind/instances/augustine/config/vufind/sitemap.ini
+++ b/local/tuefind/instances/augustine/config/vufind/sitemap.ini
@@ -1,0 +1,126 @@
+; This file contains global settings affecting sitemap generation behavior.
+;   Currently, this is accessed by the sitemap.php script in the
+;   vufind/util folder.
+; Notes:
+;   For full details on the sitemaps protocol, see:
+;     http://sitemaps.org
+;   For more information regarding best practices, see:
+;     https://vufind.org/wiki/administration:search_engine_optimization
+
+; The Sitemap Section contains settings affecting the generation of
+;   individual sitemap files
+[Sitemap]
+
+;  Frequency tells the site indexer how frequently you
+;    expect the content of the given URL entry to be updated.  The options are:
+;    always, hourly, daily, weekly, monthly, yearly and never
+;
+frequency      = yearly
+
+;  countPerPage indicates how many URL entries will appear in each outputted sitemap
+;     This is useful in case your repository is huge (as many search engines cap
+;     the number of urls in a sitemap to around 50000) or if you're indexing formats
+;     that severely reduce the amount of items that can go into a sitemap (aka
+;     images indexed in google max at 1000 per sitemap).
+countPerPage   = 10000
+
+;  fileName dictates what base name each sitemap will get.  If multiple sitemaps
+;     are generated (via the index size being larger than the countPerPage above)
+;     the subsequent name files will have a number appended to the base name.
+;     So, for example, if the code generates three sitemap files, and the basename
+;     is "sitemap", the three files will be named sitemap.xml, sitemap-2.xml and
+;     sitemap-3.xml
+fileName       = sitemap
+
+;  fileLocation dictates where the generated sitemaps will initially be saved.
+;    Note: To make sitemaps available to a site indexer, they will need to be
+;    somewhere under the /public folder of your VuFind installation, or under
+;    the web root of your server (e.g. /var/www/html or similar). Furthermore,
+;    sitemaps.org sets limitations on the paths that can be covered by a given
+;    sitemap. See http://sitemaps.org/protocol.php#location for details.
+fileLocation   = /usr/local/vufind/public/sitemaps/augustine
+
+;  This setting controls which index or indices are used to generate the sitemap
+;    (when the Index plugin is active in the plugins[] setting -- see below).
+;    Each value in the array should be a comma-separated pair, with the first
+;    value being the name of the search backend for accessing the index, and the
+;    second value being a relative path to insert between the base URL and the
+;    record ID in order to generate a link. If this setting is omitted, the
+;    default will be "Solr,/Record/"
+index[] = "Solr,/Record/"
+index[] = "SolrAuth,/AuthorityRecord/"
+;   Indexes can be completely disabled by setting this to false:
+;index = false
+
+;  This setting controls how IDs are retrieved from the index. It may be
+;  'search' (the default, most compatible but slower method), or 'terms' (the
+;    faster option). Note that 'terms' method does not support hidden filters or
+;    other limiting options and requires that the index has terms enabled.
+retrievalMode = search
+
+;  If you want to apply additional filtering to the records included in your
+;  sitemaps from the index plugin, you can specify Solr queries here. This option
+;  is ONLY supported when retrievalMode is set to search above.
+;extraFilters[] = "format:Book"
+
+;  This settings controls whether different language versions are added to the
+;    sitemap. Possible values:
+;    empty or undefined - Language versions are not added
+;    "*"                - Language versions are added for all languages enabled in
+;                         config.ini
+;    "en,de,..."        - A comma-separated list of languages to include from the
+;                         ones enabled in config.ini
+;  Note that including language versions will make the sitemap files substantially
+;    larger and may not be very useful if language detection is enabled in VuFind.
+;  Note that when a language code includes a locale (e.g. 'en-gb') and the base
+;    language (e.g. 'en') is not enabled, a fallback entry with the base language
+;    code is added automatically.
+;indexLanguageVersions = "en,de"
+
+;  This setting defines sitemap plugins to be used for adding URLs to the sitemap.
+;    If no value is set for plugins, only the Index plugin will be used. The
+;    following plugins are available in VuFind:
+;    ContentPages - Adds any content pages from templates/content to the sitemap
+;    Index        - Adds records from the Solr index to the sitemap (based on the
+;                   "index[]" settings above)
+;    StartPage    - Adds the main page for the site to the sitemap
+;plugins[] = StartPage
+;plugins[] = ContentPages
+;plugins[] = Index
+
+; The SitemapIndex Section contains settings affecting the generation of
+;   a sitemap index file which groups multiple sitemap files. The sitemap
+;   index file will contain absolute URLs to the individual sitemap files.
+[SitemapIndex]
+
+; This setting indicates the base URL at which your sitemaps are generated.  Note
+;   that in most cases it should correspond with the value of fileLocation above!
+;   It is "strongly recommended" by sitemaps.org that this location should be the
+;   root of your website!  If this is set to false or commented out, the base
+;   VuFind URL from config.ini will be used.
+baseSitemapUrl = https://augustine.ixtheo.de/sitemaps/augustine
+
+; indexFileName dictates the base name of the sitemap index file,
+;   e.g. sitemapIndex will result in sitemapIndex.xml
+; You can comment out this setting to skip index file generation.
+indexFileName  = sitemapIndex
+
+; In addition to the generated sitemap files which contain the URLs for each
+;   record, the sitemap index file can reference one or more static sitemaps for other
+;   pages in your catalogue interface such as the Advanced Search, Browse, etc.
+;
+; Each baseSitemapFileName[] entry can be in one of two possible formats: either a
+;   fully qualified URL (in which case it will be added to the sitemap without any
+;   validation) or a simple filename with no base URL or extension (in which case
+;   it will be associated with the baseSitemapUrl and given an .xml extension, and
+;   it will only be added to the sitemap index if it actually exists relative to
+;   fileLocation in the file system).
+;
+; In creating these sitemaps, you can avail of the <priority /> element to indicate
+;   the priority of these URLs relative to the record URLs which have the default
+;   priority of 0.5. baseSitemapFileName dictates the base name of this sitemap
+;   file.
+;
+; You can comment out this setting if you do not want to use a base sitemap.
+baseSitemapFileName[] = baseSitemap
+;baseSitemapFileName[] = https://myuniversity.edu/fully-qualified-example-sitemap.xml

--- a/local/tuefind/instances/augustine/config/vufind/subsystem.ini
+++ b/local/tuefind/instances/augustine/config/vufind/subsystem.ini
@@ -1,0 +1,1 @@
+subsystem = BIB

--- a/local/tuefind/instances/augustine/config/vufind/subsystem_sort.ini
+++ b/local/tuefind/instances/augustine/config/vufind/subsystem_sort.ini
@@ -1,0 +1,1 @@
+title_count_augustine desc = title_count

--- a/local/tuefind/instances/augustine/config/vufind/tuefind.ini
+++ b/local/tuefind/instances/augustine/config/vufind/tuefind.ini
@@ -1,0 +1,89 @@
+[General]
+
+; Display share buttons for social media in core template? (default false)
+;display_social_media_buttons = true
+
+; Hide controls in advanced search (default false)
+;hide_advanced_controls = true
+
+; path to generated RSS feed
+;rss_feed_path = '/usr/local/vufind/public/docs/news.rss'
+
+; use persistent cookies? (set cookie lifetime to config.ini's Session->lifetime, default false)
+persistent_cookies = true
+
+; Are users allowed to subscribe journals? (default 'disabled')
+subscriptions = enabled
+
+; Are users allowed to use PDA? (default 'disabled')
+pda = enabled
+
+; Are users allowed to subscribe rss feeds? (default 'disabled')
+;rss_subscriptions = enabled
+
+; Are users allowed to request rights on authorities? (default 'disabled')
+;request_authority_rights = enabled
+
+[Publication]
+; Are users allowed to upload publications for their authorities? (default 'disabled')
+; Please also enable 'request_authority_rights', else this option is useless.
+;publications = enabled
+
+; Email address. This will not only be referenced in help texts, but also when sending mails,
+; so it should be overridden in local_overrides.
+;email = "ixtheo-self-archiving@ub.uni-tuebingen.de"
+
+; DSpace collection that new files should be added to
+;collection_name = "IxTheo / FID Theology - Repository"
+
+;Credentials for DSpace REST API
+; The following settings should be secret and will therefore be included from local_overrides.
+; dspace_url = https://api7.dspace.org/server
+; dspace_url_base = https://demo7.dspace.org/
+; dspace_username = dspacedemo+submit@gmail.com
+; dspace_password = dspace
+;@include = 'local_overrides/ixtheo_publication.conf'
+
+; This section contains a list of languages for uploading files via the Dspace API
+[Publication_Languages]
+en               = "English"
+de               = "German"
+es               = "Spanish"
+fr               = "French"
+it               = "Italian"
+
+[KfL]
+; The first few common settings can be shared via git
+base_url = https://proxy.fid-lizenzen.de/hanapi/
+api_id = fidsso
+cipher = aes-256-ecb
+; The following settings should be secret and will therefore be included from local_overrides.
+;encryption_key = 12345678901234567890123456789012
+; The local_overrides file should be instance specific. It should also contain a list of the relevant titles
+; together with their licensing information.
+; (<han-id> + <entitlement> may differ between each instance, and as well between test and live servers):
+;titles[] = "<ppn>;<han-id>;<entitlement>"
+;@include = 'local_overrides/augustine_kfl.conf'
+
+[CMS]
+; Is this functionality enabled? (e.g. show additional buttons in the CMS menu), default false
+;enabled = true
+
+; Is the git sync functionality enabled?
+;sync_enabled = true
+
+; path to repo, this should be the same for all systems
+; make sure it is properly cloned (via SSH) and your Apache/FPM user has access to it
+; git config --global --add safe.directory /usr/local/tuefind_cms_sync
+; git config user.email "github-robot@ub.uni-tuebingen.de"
+; git config user.name "github-robot"
+repository_path = '/usr/local/tuefind_cms_sync'
+
+; branch to use, this should be similar to the hostname and set in local_overrides (ptah, ub16, ...)
+; make sure this local branch already exists and is following the proper remote branch!!!
+;repository_branch = '<replace by your hostname>'
+
+; paths to local SSH key for git, this must be accessible from your PHP process in Apache/FPM context!
+;ssh_key_path = '/tmp/github-robot'
+
+;@include = 'local_overrides/cms.conf'

--- a/local/tuefind/instances/augustine/harvest/README.txt
+++ b/local/tuefind/instances/augustine/harvest/README.txt
@@ -1,0 +1,2 @@
+OAI-PMH Metadata will be harvested to this directory when the VUFIND_LOCAL_DIR
+environment variable is properly configured.

--- a/local/tuefind/instances/augustine/languages
+++ b/local/tuefind/instances/augustine/languages
@@ -1,0 +1,1 @@
+../../languages

--- a/module/IxTheo/sql/migrations/mysql/11.0/002-ixtheo-subsystems.sql
+++ b/module/IxTheo/sql/migrations/mysql/11.0/002-ixtheo-subsystems.sql
@@ -1,6 +1,7 @@
 INSERT INTO tuefind_subsystems (subsystem)
-VALUES 
+VALUES
   ('ixtheo'),
   ('relbib'),
   ('bibstudies'),
-  ('churchlaw');
+  ('churchlaw'),
+  ('augustine');

--- a/module/IxTheo/sql/mysql.sql
+++ b/module/IxTheo/sql/mysql.sql
@@ -34,7 +34,7 @@ CREATE TABLE ixtheo_pda_subscriptions (
     CONSTRAINT `user_id_pda_subscription` FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8;
 
-ALTER TABLE user ADD COLUMN ixtheo_user_type ENUM('ixtheo', 'relbib', 'bibstudies', 'churchlaw') NOT NULL DEFAULT 'ixtheo';
+ALTER TABLE user ADD COLUMN ixtheo_user_type ENUM('ixtheo', 'relbib', 'bibstudies', 'churchlaw', 'augustine') NOT NULL DEFAULT 'ixtheo';
 ALTER TABLE user ADD COLUMN ixtheo_appellation VARCHAR(64) DEFAULT NULL;
 ALTER TABLE user ADD COLUMN ixtheo_title VARCHAR(64) DEFAULT NULL;
 ALTER TABLE user ADD COLUMN ixtheo_can_use_tad BOOLEAN DEFAULT FALSE;
@@ -46,8 +46,9 @@ CREATE UNIQUE INDEX `subsystem_username` ON user (`ixtheo_user_type`, `username`
 CREATE UNIQUE INDEX `subsystem_email` ON user (`ixtheo_user_type`, `email`);
 
 INSERT INTO tuefind_subsystems (subsystem)
-VALUES 
+VALUES
   ('ixtheo'),
   ('relbib'),
   ('bibstudies'),
-  ('churchlaw');
+  ('churchlaw'),
+  ('augustine');

--- a/module/IxTheo/src/IxTheo/View/Helper/IxTheo/IxTheo.php
+++ b/module/IxTheo/src/IxTheo/View/Helper/IxTheo/IxTheo.php
@@ -213,6 +213,8 @@ class IxTheo extends \Laminas\View\Helper\AbstractHelper
                 return 'bibstudies-beacon.txt';
             case 'churchlaw':
                 return 'canonlaw-beacon.txt';
+            case 'augustine':
+                return 'augustine-beacon.txt';
             default:
                 return 'ixtheo-beacon.txt';
         }

--- a/module/TueFind/src/TueFind/View/Helper/TueFind/TueFind.php
+++ b/module/TueFind/src/TueFind/View/Helper/TueFind/TueFind.php
@@ -370,7 +370,9 @@ class TueFind extends \Laminas\View\Helper\AbstractHelper implements
         $map = ['ixtheo' => 'ixtheo',
                 'relbib' => 'relbib',
                 'bibstudies' => 'biblestudies',
-                'churchlaw' => 'canonlaw'];
+                'churchlaw' => 'canonlaw',
+                'augustine' => 'augustine',
+            ];
         return $map[$instance] ?? $instance;
     }
 
@@ -380,7 +382,9 @@ class TueFind extends \Laminas\View\Helper\AbstractHelper implements
                 'relbib',
                 'bibstudies',
                 'canonlaw',
-                'krimdok'];
+                'augustine',
+                'krimdok',
+            ];
         return $map;
     }
 
@@ -397,6 +401,7 @@ class TueFind extends \Laminas\View\Helper\AbstractHelper implements
             case 'ixtheo':
             case 'bibstudies':
             case 'churchlaw':
+            case 'augustine':
                 return 'IxTheo';
             case 'relbib':
                 return 'RelBib';
@@ -422,6 +427,8 @@ class TueFind extends \Laminas\View\Helper\AbstractHelper implements
                 return 'BIB';
             case 'churchlaw':
                 return 'CAN';
+            case 'augustine':
+                return 'AUG';
             case 'relbib':
                 return 'REL';
             case 'krimdok':
@@ -444,6 +451,7 @@ class TueFind extends \Laminas\View\Helper\AbstractHelper implements
             case 'ixtheo':
             case 'bibstudies':
             case 'churchlaw':
+            case 'augustine':
                 $fid = 'Theologie';
                 break;
             case 'relbib':

--- a/solr/vufind/biblio/conf/schema_ixtheo_fields.xml
+++ b/solr/vufind/biblio/conf/schema_ixtheo_fields.xml
@@ -39,6 +39,7 @@
     <field name="geographic_facet_pt" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="geographic_facet_ru" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="has_ita_t_subfield" type="boolean" indexed="true" stored="true" multiValued="false"/>
+    <field name="is_augustine" type="boolean" indexed="true" stored="true" multiValued="false"/>
     <field name="is_biblical_studies" type="boolean" indexed="true" stored="true" multiValued="false"/>
     <field name="is_canon_law" type="boolean" indexed="true" stored="true" multiValued="false"/>
     <field name="is_hybrid" type="boolean" indexed="true" stored="true" multiValued="false"/>

--- a/themes/augustine/scss/compiled.scss
+++ b/themes/augustine/scss/compiled.scss
@@ -1,0 +1,3 @@
+@use "../../ixtheo2/scss/compiled";
+@use "variables";
+@use "overrides";

--- a/themes/augustine/scss/overrides.scss
+++ b/themes/augustine/scss/overrides.scss
@@ -1,0 +1,7 @@
+.main_search_form {
+    background-color: #eee9dc;
+}
+
+.panel-home h1 a {
+    color: #000;
+}

--- a/themes/augustine/templates/content/Home.phtml
+++ b/themes/augustine/templates/content/Home.phtml
@@ -1,0 +1,1 @@
+<?php // empty so far ?>

--- a/themes/augustine/templates/header.phtml
+++ b/themes/augustine/templates/header.phtml
@@ -1,0 +1,130 @@
+<?php $account = $this->auth()->getManager(); ?>
+<div class="banner search container">
+  <div class="row pt-2">
+    <div class="navbar-header col-2">
+      <a class="navbar-brand lang-<?=$this->layout()->userLang ?>" href="<?=$this->url('home')?>"><?=$this->translate("IxAug")?></a>
+    </div>
+    <div class="col-10">
+      <?php if (!isset($this->layout()->renderingError)): ?>
+        <div class="navbar-collapse" id="header-collapse">
+          <nav id="ix-nav-header" class="navbar navbar-expand-lg">
+            <ul class="nav navbar-nav navbar-right flip ms-auto">
+              <li class="active"><a href="<?=$this->url('home')?>"><?=$this->transEsc('Home');?></a></li>
+              <li class="dropdown">
+                <a class="dropdown-toggle" data-bs-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false"><?=$this->transEsc('About');?> &nbsp;<?=$this->icon('dropdown-caret') ?></a>
+                <ul class="dropdown-menu">
+                  <li><a href="/Content/Impressum"><?=$this->transEsc('Impressum');?></a></li>
+                  <li><a target="_blank" href="<?=$this->url('content-page', ['page' => 'privacy'])?>"><?=$this->transEsc('Privacy Protection');?></a></li>
+                </ul>
+              </li>
+              <li><a href="/Content/A-Z">IxTheo A-Z</a></li>
+              <?php if ($this->feedback()->tabEnabled()): ?>
+                <li>
+                  <a id="feedbackLink" data-lightbox href="<?=$this->url('feedback-home') ?>"><i class="fa fa-envelope" aria-hidden="true"></i> <?=$this->transEsc("Feedback")?></a>
+                </li>
+              <?php endif; ?>
+              <?php $cart = $this->cart(); if ($cart->isActive()): ?>
+                <li id="cartSummary">
+                  <a id="cartItems" data-lightbox title="<?=$this->transEsc('View Book Bag')?>" href="<?=$this->url('cart-home')?>">
+                    <i class="fa fa-suitcase" aria-hidden="true"></i> <strong><?=count($cart->getItems())?></strong> <?=$this->transEsc('items')?>
+                    <span class="full<?=!$cart->isFull() ? ' hidden' : '' ?>">(<?=$this->transEsc('bookbag_full') ?>)</span>
+                  </a>
+                </li>
+              <?php endif; ?>
+              <?php if (is_object($account) && $account->loginEnabled()): // hide login/logout if unavailable ?>
+                <li class="logoutOptions<?php if($account->dropdownEnabled()): ?> with-dropdown<?php endif ?><?php if(!$account->getIdentity()): ?> hidden<?php endif ?>">
+                  <a href="<?=$this->url('myresearch-home', [], ['query' => ['redirect' => 0]])?>"><i id="account-icon" class="fa fa-user-circle" aria-hidden="true"></i> <?=$this->transEsc("Your Account")?></a>
+                </li>
+                <?php if($account->dropdownEnabled()): ?>
+                  <li id="login-dropdown" class="dropdown<?php if(!$account->getIdentity()): ?> hidden<?php endif ?>">
+                    <a href="#" data-bs-toggle="dropdown"><i class="fa fa-caret-down"></i></a>
+                    <div class="dropdown-menu">
+                      <?=$this->render('myresearch/menu'); ?>
+                    </div>
+                  </li>
+                <?php endif; ?>
+                <li class="logoutOptions<?php if(!$account->getIdentity()): ?> hidden<?php endif ?>">
+                  <a href="<?=$this->url('myresearch-logout')?>" class="logout"><i class="fa fa-sign-out" aria-hidden="true"></i> <?=$this->transEsc("Log Out")?></a>
+                </li>
+                <li id="loginOptions"<?php if($account->getIdentity()): ?> class="hidden"<?php endif ?>>
+                  <?php if ($account->getSessionInitiator($this->serverUrl($this->url('myresearch-home')))): ?>
+                    <a href="<?=$this->url('myresearch-userlogin')?>"><i class="fa fa-sign-in" aria-hidden="true"></i> <?=$this->transEsc("Institutional Login")?></a>
+                  <?php else: ?>
+                    <a href="<?=$this->url('myresearch-userlogin')?>" data-lightbox><i class="fa fa-sign-in" aria-hidden="true"></i> <?=$this->transEsc("Login")?></a>
+                  <?php endif; ?>
+                </li>
+              <?php endif; ?>
+
+              <?php if (isset($this->layout()->themeOptions) && count($this->layout()->themeOptions) > 1): ?>
+                <li class="theme dropdown">
+                  <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><?=$this->transEsc("Theme")?> &nbsp;<?=$this->icon('dropdown-caret') ?></a>
+                  <ul class="dropdown-menu">
+                    <?php foreach ($this->layout()->themeOptions as $current): ?>
+                      <li<?=$current['selected'] ? ' class="active"' : ''?>>
+                        <a href="<?=$this->escapeHtmlAttr($this->url()->addQueryParameters(['ui' => $current['name']])) ?>" rel="nofollow">
+                          <?=$this->transEsc($current['desc']) ?>
+                        </a>
+                      </li>
+                    <?php endforeach; ?>
+                  </ul>
+                </li>
+              <?php endif; ?>
+
+              <?php if (isset($this->layout()->allLangs) && count($this->layout()->allLangs) > 1): ?>
+                <li class="language dropdown">
+                <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown"><i class="fa fa-globe" aria-hidden="true"></i> <?=$this->transEsc("Language")?> &nbsp;<?=$this->icon('dropdown-caret') ?></a>
+                <ul class="dropdown-menu">
+                    <?php
+                      //TueFind: Basic VuFind functionality changed, removed author ID from URL
+                      $routeParams = $this->tuefind()->getRouteParams();
+                      foreach ($this->layout()->allLangs as $langCode => $langName): ?>
+                        <li<?=$this->layout()->userLang == $langCode ? ' class="active"' : ''?>>
+                          <?php $langURL = $this->escapeHtmlAttr($this->url()->addQueryParameters(['lng' => $langCode]));
+                              if($routeParams['controller'] == "Authority" && $routeParams['action'] == "Home") {
+                                  $langURL = $this->escapeHtmlAttr($this->url()->addQueryParametersToAuthority(['lng' => $langCode]));
+                              }
+                          ?>
+                          <a href="<?=$langURL?>" rel="nofollow">
+                            <?=$this->displayLanguageOption($langName) ?>
+                          </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+              </li>
+              <?php endif; ?>
+          </ul>
+        </nav>
+      </div>
+      <?php endif; ?>
+    </div>
+  </div>
+  <section class="section-home">
+    <div class="panel-home">
+      <br />
+      <br />
+      <div class="visible-lg">
+        <h1>
+          <a href="<?=$this->url('home')?>" title="Index Augustinianus">Index Augustinianus</a>
+        </h1>
+        <!--<h3 class="text-center"><?=$this->transEsc('Exegetics')?></h3>-->
+        <!--The following subtitle will be translated as soon as more information is available-->
+        <!--<small>Internationale Bibliographie für Bibelwissenschaften</small>-->
+        <br />
+      </div>
+      <?php if ($this->ils()->getOfflineMode() == "ils-offline"): ?>
+        <div class="alert alert-warning">
+          <h2><?= $this->transEsc('ils_offline_title') ?></h2>
+
+          <p><strong><?= $this->transEsc('ils_offline_status') ?></strong></p>
+
+          <p><?= $this->transEsc('ils_offline_home_message') ?></p>
+          <?php $supportEmail = $this->escapeHtmlAttr($this->systemEmail()); ?>
+          <p><a href="mailto:<?= $supportEmail ?>"><?= $supportEmail ?></a></p>
+        </div>
+      <?php endif; ?>
+        <nav class="nav searchbox hidden-print">
+          <?=$this->layout()->searchbox ?>
+        </nav>
+    </div>
+  </section>
+</div>

--- a/themes/augustine/theme.config.php
+++ b/themes/augustine/theme.config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'extends' => 'ixtheo2',
+    'css' => [
+        'compiled.css'
+    ],
+];


### PR DESCRIPTION
TODO:
- [x] Add basic instance configuration
- [x] Add basic theme / inherit from ixtheo2 (ugly so far, can be improved later)
- [x] Register new Instance
  - [x] MySQL
  - [x] View Helpers
- [x] Create Solr field
  - [ ] ub_tools: Add `AUG` (similar to `BIB`) in pipeline programs (first shot: 935a must be one of `bami` `wumi` `AUGU`, or 852a must contain `DE-4020`), see ubtue/ub_tools#4716
  - [x] Index Solr field
- [x] Create several new folders, register new instance for cache cleanup, etc.
- [ ] Later:
  - [ ] Change docker container setups to also setup test instance, create augustine_site.conf, ...
  - [ ] Enable alphabetical browse indexing (inactive for now to avoid slower indexing performance on servers)
  - [ ] Check which subdomains will be necessary for live server configuration, DNS registration, SSL certificates, ...

Steps for Setup:
- `touch local_overrides/augustine_site.conf`
- `chown -R vufind:vufind local/tuefind/instances/augustine/cache`
- MySQL:
  - `INSERT INTO tuefind_subsystems (subsystem) VALUES ('augustine');`
  - `ALTER TABLE user MODIFY COLUMN ixtheo_user_type ENUM('ixtheo', 'relbib', 'bibstudies', 'churchlaw', 'augustine') NOT NULL DEFAULT 'ixtheo';`
- (Register new instance in apache config)